### PR TITLE
fix: removed relative path from docker file. So that users can define…

### DIFF
--- a/.env.docker-compose
+++ b/.env.docker-compose
@@ -17,7 +17,7 @@ DB_HOST=db
 # Service name in docker-compose or local db
 DB_PORT=5432
 DB_SCHEMA=${NETWORK}
-DB_PATH=/data
+DB_PATH=./data
 
 ## Cardano Node variables
 CARDANO_NODE_HOST=cardano-node
@@ -27,10 +27,10 @@ CARDANO_NODE_PORT=3001
 CARDANO_NODE_VERSION=8.9.0
 CARDANO_NODE_SUBMIT_HOST=cardano-submit-api
 NODE_SUBMIT_API_PORT=8090
-CARDANO_NODE_SOCKET_PATH=/node
+CARDANO_NODE_SOCKET_PATH=./node
 CARDANO_NODE_SOCKET=${CARDANO_NODE_SOCKET_PATH}/node.socket
-CARDANO_NODE_DB=/node/db
-CARDANO_CONFIG=/config/${NETWORK}
+CARDANO_NODE_DB=./node/db
+CARDANO_CONFIG=./config/${NETWORK}
 
 ## Api env
 API_DOCKER_IMAGE_TAG=main
@@ -40,6 +40,7 @@ API_PORT=8082
 PRINT_EXCEPTION=true
 
 ROSETTA_VERSION=1.4.13
+# Paths used in Container
 TOPOLOGY_FILEPATH=/config/topology.json
 GENESIS_SHELLEY_PATH=/config/shelley-genesis.json
 GENESIS_BYRON_PATH=/config/byron-genesis.json

--- a/docker-api-indexer.yaml
+++ b/docker-api-indexer.yaml
@@ -27,8 +27,8 @@ services:
       DEVKIT_URL: ${DEVKIT_URL}
       DEVKIT_PORT: ${DEVKIT_PORT}
     volumes:
-      - ./${CARDANO_CONFIG}:/config
-      - ./${CARDANO_NODE_SOCKET_PATH}:${CARDANO_NODE_SOCKET_PATH}
+      - ${CARDANO_CONFIG}:/config
+      - ${CARDANO_NODE_SOCKET_PATH}:${CARDANO_NODE_SOCKET_PATH}
     healthcheck:
       test: [ "CMD-SHELL", "curl --fail http://localhost:${API_PORT}/network/options -H 'Content-Type: application/json' --data '{\"metadata\": {}}' -X POST" ]
       interval: 30s
@@ -63,7 +63,7 @@ services:
       GENESIS_CONWAY_PATH: ${GENESIS_CONWAY_PATH}
       INITIAL_BALANCE_CALCULATION_BLOCK: ${INITIAL_BALANCE_CALCULATION_BLOCK}
     volumes:
-      - ./${CARDANO_CONFIG}:/config
+      - ${CARDANO_CONFIG}:/config
     restart: always
     depends_on:
       db:
@@ -81,7 +81,7 @@ services:
       POSTGRES_DB: ${DB_NAME}
     restart: on-failure
     volumes:
-      - ./${DB_PATH}:/var/lib/postgresql/data
+      - ${DB_PATH}:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME} -p ${DB_PORT} -h localhost"]
       interval: 10s

--- a/docker-node.yaml
+++ b/docker-node.yaml
@@ -5,9 +5,9 @@ services:
     environment:
       - NETWORK=${NETWORK}
     volumes:
-      - ./${CARDANO_NODE_SOCKET_PATH}:${CARDANO_NODE_SOCKET_PATH}
-      - ./${CARDANO_NODE_DB}:/data/db
-      - ./${CARDANO_CONFIG}:/config
+      - ${CARDANO_NODE_SOCKET_PATH}:${CARDANO_NODE_SOCKET_PATH}
+      - ${CARDANO_NODE_DB}:/data/db
+      - ${CARDANO_CONFIG}:/config
     ports:
       - ${CARDANO_NODE_PORT}:${CARDANO_NODE_PORT}
     entrypoint: cardano-node run --database-path /data/db --port ${CARDANO_NODE_PORT} --socket-path ${CARDANO_NODE_SOCKET} --topology /config/topology.json --config /config/config.json
@@ -19,7 +19,7 @@ services:
     depends_on:
       - cardano-node
     volumes:
-      - ./${CARDANO_NODE_SOCKET_PATH}:/node-ipc
+      - ${CARDANO_NODE_SOCKET_PATH}:/node-ipc
     ports:
       - ${NODE_SUBMIT_API_PORT}:8090
     restart: on-failure


### PR DESCRIPTION
Don't use "./${ENV_VAR}". This implies for the developer using the .envFiles, that he can set the paths completely and the prefix will hinder that. 