### PR TITLE
update topology file to include CF bootstrap peers

### DIFF
--- a/config/mainnet/topology.json
+++ b/config/mainnet/topology.json
@@ -7,6 +7,10 @@
     {
       "address": "backbone.mainnet.emurgornd.com",
       "port": 3001
+    },
+    {
+      "address": "backbone.mainnet.cardanofoundation.org",
+      "port": 3001
     }
   ],
   "localRoots": [


### PR DESCRIPTION
The current topology file for mainnet only has IOG and Emurgo bootstrap nodes.

I've added the configuration from https://book.world.dev.cardano.org/environments/mainnet/topology.json
