### PR TITLE
fix: implemented default return of the latest block for /block endpoint. 

### DIFF
--- a/api/src/main/java/org/cardanofoundation/rosetta/api/block/service/LedgerBlockServiceImpl.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/block/service/LedgerBlockServiceImpl.java
@@ -75,6 +75,8 @@ public class LedgerBlockServiceImpl implements LedgerBlockService {
       return blockRepository.findByNumber(blockNumber).map(this::toModelFrom);
     } else if (blockHash != null && blockNumber == null) {
       return blockRepository.findByHash(blockHash).map(this::toModelFrom);
+    } else if (blockHash == null && blockNumber == null) {
+      return blockRepository.findLatestBlock().map(this::toModelFrom);
     } else {
       return blockRepository
           .findByNumberAndHash(blockNumber, blockHash)


### PR DESCRIPTION
This fix will return the latest block as default. So if now blockidentifier is provided it will automatically return the latest block.