### PR TITLE
fix: search transactions don't use address filter

### DIFF
--- a/api/src/main/java/org/cardanofoundation/rosetta/api/account/model/repository/AddressUtxoRepository.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/account/model/repository/AddressUtxoRepository.java
@@ -27,7 +27,8 @@ public interface AddressUtxoRepository extends JpaRepository<AddressUtxoEntity, 
   @Query(value =
       """
       SELECT a.txHash FROM AddressUtxoEntity a
-      WHERE a.ownerStakeAddr = :address
+      WHERE a.ownerAddr = :address
+      OR a.ownerStakeAddr = :address
       """)
   List<String> findTxHashesByOwnerAddr(@Param("address") String ownerAddr);
 

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/search/service/LedgerSearchServiceImpl.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/search/service/LedgerSearchServiceImpl.java
@@ -41,7 +41,17 @@ public class LedgerSearchServiceImpl implements LedgerSearchService {
     List<TxnEntity> txnEntities;
     Set<String> txHashes = new HashSet<>();
     Optional.ofNullable(txHash).ifPresent(txHashes::add);
-    Optional.ofNullable(address).ifPresent(addr -> txHashes.addAll(addressUtxoRepository.findTxHashesByOwnerAddr(addr)));
+
+    Optional<String> addressOptional = Optional.ofNullable(address);
+    Set<String> addressTxHashes = new HashSet<>();
+    addressOptional.ifPresent(addr -> addressTxHashes.addAll(addressUtxoRepository.findTxHashesByOwnerAddr(addr)));
+    // If Address was set and there weren't any transactions found, return empty list
+    if (addressOptional.isPresent() && addressTxHashes.isEmpty()) {
+      return List.of();
+    } else {
+      txHashes.addAll(addressTxHashes);
+    }
+
     Optional.ofNullable(utxoKey).ifPresent(utxo -> {
       txHashes.add(utxo.getTxHash());
       txHashes.addAll(txInputRepository.findSpentTxHashByUtxoKey(utxoKey.getTxHash(), utxoKey.getOutputIndex()));

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/search/service/SearchControllerIntTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/search/service/SearchControllerIntTest.java
@@ -28,7 +28,7 @@ class SearchControllerIntTest extends IntegrationTest {
         .build();
 
     List<BlockTransaction> blockTransactions = service.searchTransaction(req, 0L, 5L);
-    assertEquals(5, blockTransactions.size());
+    assertEquals(4, blockTransactions.size());
   }
 
   @Test


### PR DESCRIPTION
- Fixed a bug, where only stakeaddresses were used to filter for addresses
- Changed behaviour of search - If address is set and no txHashes were found, return an empty list