### PR TITLE
fix: /construction/parse endpoint - incorrect nesting assumptions for amount that is part of token bundle, now it should be correct.

### DIFF
--- a/api/src/main/java/org/cardanofoundation/rosetta/api/construction/service/OperationService.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/construction/service/OperationService.java
@@ -80,16 +80,19 @@ public class OperationService {
       List<Operation> operations) {
     List<TransactionInput> inputs = transactionBody.getInputs();
     log.info("[fillInputOperations] About to parse {} inputs", inputs.size());
-    List<Operation> inputOperations = extraData.operations().stream()
+    List<Operation> extraDataInputOperations = extraData.operations().stream()
         .filter(o -> o.getType().equals(OperationType.INPUT.getValue()))
         .toList();
+
     for (int i = 0; i < inputs.size(); i++) {
-      if (!inputOperations.isEmpty() && inputOperations.size() <= inputs.size()) {
-        operations.add(inputOperations.get(i));
-      } else {
+      if (!extraDataInputOperations.isEmpty() && extraDataInputOperations.size() <= inputs.size()) {
+        operations.add(extraDataInputOperations.get(i));
+      } else { // fallback in case of no extra data input operations
         TransactionInput input = inputs.get(i);
+
         Operation inputParsed = ParseConstructionUtil.transactionInputToOperation(input,
             (long) operations.size());
+
         operations.add(inputParsed);
       }
     }
@@ -99,7 +102,9 @@ public class OperationService {
     List<TransactionOutput> outputs = transactionBody.getOutputs();
     List<OperationIdentifier> relatedOperations = ParseConstructionUtil.getRelatedOperationsFromInputs(
         operations);
+
     log.info("[parseOperationsFromTransactionBody] About to parse {} outputs", outputs.size());
+
     for (TransactionOutput output : outputs) {
       Operation outputParsed = ParseConstructionUtil.transActionOutputToOperation(output,
           (long) operations.size(),
@@ -132,6 +137,7 @@ public class OperationService {
     operations.addAll(withdrawalsOperations);
   }
 
+  // TODO catalyst voting renaming?
   private void fillVoteOperations(TransactionExtraData extraData, List<Operation> operations)
       throws CborDeserializationException {
     List<Operation> voteOp = extraData.operations().stream()

--- a/api/src/main/java/org/cardanofoundation/rosetta/common/mapper/CborArrayToTransactionData.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/common/mapper/CborArrayToTransactionData.java
@@ -25,10 +25,14 @@ public class CborArrayToTransactionData {
     TransactionExtraData extraData = CborMapToTransactionExtraData.convertCborMapToTransactionExtraData(
         (Map) decodedTransaction.getDataItems().get(1));
 
-    byte[] bytes = HexUtil.decodeHexString(
+    byte[] transactionBytes = HexUtil.decodeHexString(
         ((UnicodeString) decodedTransaction.getDataItems().get(0)).getString());
 
-    return signed ? processSignedTransaction(bytes, extraData) : processUnsignedTransaction(bytes, extraData);
+    if (signed) {
+      return processSignedTransaction(transactionBytes, extraData);
+    }
+
+    return processUnsignedTransaction(transactionBytes, extraData);
   }
 
   private static TransactionData processSignedTransaction(byte[] bytes, TransactionExtraData extraData)

--- a/api/src/main/java/org/cardanofoundation/rosetta/common/mapper/CborMapToOperation.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/common/mapper/CborMapToOperation.java
@@ -37,920 +37,930 @@ import static org.cardanofoundation.rosetta.common.util.Formatters.key;
 
 public class CborMapToOperation {
 
-  private CborMapToOperation() {}
+    private CborMapToOperation() {}
 
-  public static Operation cborMapToOperation(Map operationMap) {
-    Operation operation = new Operation();
+    public static Operation cborMapToOperation(Map operationMap) {
+        Operation operation = new Operation();
 
-    addOperationIdentifierToOperation(operation, operationMap);
-    addRelatedOperationToOperation(operation, operationMap);
+        addOperationIdentifierToOperation(operation, operationMap);
+        addRelatedOperationToOperation(operation, operationMap);
 
-    addTypeToOperation(operationMap, operation);
-    addStatusToOperation(operationMap, operation);
-    addAccountIdentifierToOperation(operationMap, operation);
+        addTypeToOperation(operationMap, operation);
+        addStatusToOperation(operationMap, operation);
+        addAccountIdentifierToOperation(operationMap, operation);
 
-    addAmount(operationMap, operation);
-    addCoinChange(operationMap, operation);
-    addMetadata(operationMap, operation);
-    return operation;
-  }
+        addAmount(operationMap, operation);
+        addCoinChange(operationMap, operation);
+        addMetadata(operationMap, operation);
 
-  /**
-   * Adding an OperationIdentifier object to the Operation object populated from the cbor MAP if not null.
-   * Accessed through {@value Constants#OPERATION_IDENTIFIER}
-   * @param operation The Operation object to fill
-   * @param operationMap The map containing the operation identifier field
-   */
-  private static void addOperationIdentifierToOperation(Operation operation, Map operationMap) {
-    Optional.ofNullable(operationMap.get(key(Constants.OPERATION_IDENTIFIER))).ifPresent(map -> {
-      Map operationIdentifierMap = (Map) map;
-      OperationIdentifier operationIdentifier = new OperationIdentifier();
-      fillOperationIdentifier(operationIdentifierMap, operationIdentifier);
-      operation.setOperationIdentifier(operationIdentifier);
-    });
-  }
+        return operation;
+    }
 
-  /**
-   * Adding a List of RelatedOperations to operation populated from cbor Map if not null.
-   * Accessed through {@value Constants#RELATED_OPERATION}
-   * @param operation The Operation object to fill
-   * @param operationMap The map containing the related operations field
-   */
-  private static void addRelatedOperationToOperation(Operation operation, Map operationMap) {
-    Optional.ofNullable(operationMap.get(new UnicodeString(Constants.RELATED_OPERATION)))
-        .ifPresent(o -> {
-          List<OperationIdentifier> relatedOperations = new ArrayList<>();
-          List<DataItem> relatedOperationsDataItems = ((Array) o).getDataItems();
-          relatedOperationsDataItems.forEach(rDI -> {
-            Map relatedOperationMap = (Map) rDI;
-
-            OperationIdentifier relatedOperationIdentifier = new OperationIdentifier();
-            fillOperationIdentifier(relatedOperationMap, relatedOperationIdentifier);
-            relatedOperations.add(relatedOperationIdentifier);
-          });
-          operation.setRelatedOperations(relatedOperations);
+    /**
+     * Adding an OperationIdentifier object to the Operation object populated from the cbor MAP if not null.
+     * Accessed through {@value Constants#OPERATION_IDENTIFIER}
+     * @param operation The Operation object to fill
+     * @param operationMap The map containing the operation identifier field
+     */
+    private static void addOperationIdentifierToOperation(Operation operation, Map operationMap) {
+        Optional.ofNullable(operationMap.get(key(Constants.OPERATION_IDENTIFIER))).ifPresent(map -> {
+            Map operationIdentifierMap = (Map) map;
+            OperationIdentifier operationIdentifier = new OperationIdentifier();
+            fillOperationIdentifier(operationIdentifierMap, operationIdentifier);
+            operation.setOperationIdentifier(operationIdentifier);
         });
-  }
+    }
 
-  /**
-   * Adding Index and NetworkIndex to OperationIdentifier from cbor MAP if not null.
-   * Access through {@value Constants#INDEX} and {@value Constants#NETWORK_INDEX}
-   * @param operationIdentifierMap The map containing the operation identifier field
-   * @param operationIdentifier The OperationIdentifier object to fill
-   */
-  private static void fillOperationIdentifier(Map operationIdentifierMap,
-      OperationIdentifier operationIdentifier) {
-    Optional.ofNullable(operationIdentifierMap.get(key(Constants.INDEX)))
-        .ifPresent(index -> operationIdentifier.setIndex(((UnsignedInteger) index).getValue().longValue()));
-    Optional.ofNullable(operationIdentifierMap.get(key(Constants.NETWORK_INDEX)))
-        .ifPresent(index -> operationIdentifier.setNetworkIndex(((UnsignedInteger) index).getValue().longValue()));
-  }
+    /**
+     * Adding a List of RelatedOperations to operation populated from cbor Map if not null.
+     * Accessed through {@value Constants#RELATED_OPERATION}
+     * @param operation The Operation object to fill
+     * @param operationMap The map containing the related operations field
+     */
+    private static void addRelatedOperationToOperation(Operation operation, Map operationMap) {
+        Optional.ofNullable(operationMap.get(new UnicodeString(Constants.RELATED_OPERATION)))
+                .ifPresent(o -> {
+                    List<OperationIdentifier> relatedOperations = new ArrayList<>();
+                    List<DataItem> relatedOperationsDataItems = ((Array) o).getDataItems();
+                    relatedOperationsDataItems.forEach(rDI -> {
+                        Map relatedOperationMap = (Map) rDI;
 
-  /**
-   * Filling the type field of the Operation object from the cbor MAP  if not null.
-   * Accessed through {@value Constants#TYPE}
-   * @param operationMap The map containing the type field
-   * @param operation The Operation object to fill
-   */
-  private static void addTypeToOperation(Map operationMap, Operation operation) {
-    Optional.ofNullable(operationMap.get(key(Constants.TYPE))).ifPresent(o -> {
-      String status = ((UnicodeString) o).getString();
-      operation.setType(status);
-    });
-  }
-  /**
-   * Filling the status field of the Operation object from the cbor MAP  if not null.
-   * Accessed through {@value Constants#STATUS}
-   * @param operationMap The map containing the status field
-   * @param operation The Operation object to fill
-   */
-  private static void addStatusToOperation(Map operationMap, Operation operation) {
-    Optional.ofNullable(operationMap.get(key(Constants.STATUS))).ifPresent(o -> {
-      String status = ((UnicodeString) o).getString();
-      operation.setStatus(status);
-    });
-  }
+                        OperationIdentifier relatedOperationIdentifier = new OperationIdentifier();
+                        fillOperationIdentifier(relatedOperationMap, relatedOperationIdentifier);
+                        relatedOperations.add(relatedOperationIdentifier);
+                    });
+                    operation.setRelatedOperations(relatedOperations);
+                });
+    }
 
-  /**
-   * Adding an AccountIdentifier object populated from the cbor MAP  if not null.
-   * Accessed through {@value Constants#ACCOUNT}
-   * @param operationMap The map containing the account field
-   * @param operation The Operation object to fill
-   */
-  private static void addAccountIdentifierToOperation(Map operationMap, Operation operation) {
-    Optional.ofNullable(operationMap.get(key(Constants.ACCOUNT))).ifPresent(o -> {
-      Map accountIdentifierMap = (Map) o;
-      AccountIdentifier accountIdentifier = new AccountIdentifier();
-      // fill object
-      addAddressToAccountIdentifier(accountIdentifierMap, accountIdentifier);
-      addSubAccountToAccountIdentifier(accountIdentifierMap, accountIdentifier);
-      addMetaDataToAccountIdentifier(accountIdentifierMap, accountIdentifier);
-      // write to Operation
-      operation.setAccount(accountIdentifier);
-    });
-  }
+    /**
+     * Adding Index and NetworkIndex to OperationIdentifier from cbor MAP if not null.
+     * Access through {@value Constants#INDEX} and {@value Constants#NETWORK_INDEX}
+     * @param operationIdentifierMap The map containing the operation identifier field
+     * @param operationIdentifier The OperationIdentifier object to fill
+     */
+    private static void fillOperationIdentifier(Map operationIdentifierMap,
+                                                OperationIdentifier operationIdentifier) {
+        Optional.ofNullable(operationIdentifierMap.get(key(Constants.INDEX)))
+                .ifPresent(index -> operationIdentifier.setIndex(((UnsignedInteger) index).getValue().longValue()));
+        Optional.ofNullable(operationIdentifierMap.get(key(Constants.NETWORK_INDEX)))
+                .ifPresent(index -> operationIdentifier.setNetworkIndex(((UnsignedInteger) index).getValue().longValue()));
+    }
 
-  /**
-   * Adding Metadata to the AccountIdentifier from the cbor MAP  if not null.
-   * Accessed through {@value Constants#METADATA}
-   * @param accountIdentifierMap The map containing the amount field
-   * @param accountIdentifier The Operation object to fill
-   */
-  private static void addMetaDataToAccountIdentifier(Map accountIdentifierMap, AccountIdentifier accountIdentifier) {
-    Optional.ofNullable(accountIdentifierMap.get(key(Constants.METADATA)))
-        .ifPresent(o -> {
-          Map accountIdentifierMetadataMap = (Map) o;
-          AccountIdentifierMetadata accountIdentifierMetadata = new AccountIdentifierMetadata();
-          // fill object
-          addChainCodeToAccountIdentifierMetadata(accountIdentifierMetadataMap, accountIdentifierMetadata);
-          // write to AccountIdentifier
-          accountIdentifier.setMetadata(accountIdentifierMetadata);
+    /**
+     * Filling the type field of the Operation object from the cbor MAP  if not null.
+     * Accessed through {@value Constants#TYPE}
+     * @param operationMap The map containing the type field
+     * @param operation The Operation object to fill
+     */
+    private static void addTypeToOperation(Map operationMap, Operation operation) {
+        Optional.ofNullable(operationMap.get(key(Constants.TYPE))).ifPresent(o -> {
+            String status = ((UnicodeString) o).getString();
+            operation.setType(status);
         });
-  }
-
-  /**
-   * Filling the ChainCode field of the AccountIdentifierMetadata object from the cbor MAP  if not null.
-   * Accessed through {@value Constants#CHAIN_CODE}
-   * @param accountIdentifierMetadataMap The map containing the chain code field
-   * @param accountIdentifierMetadata The AccountIdentifierMetadata object to fill
-   */
-  private static void addChainCodeToAccountIdentifierMetadata(Map accountIdentifierMetadataMap,
-      AccountIdentifierMetadata accountIdentifierMetadata) {
-    Optional.ofNullable(accountIdentifierMetadataMap.get(key(Constants.CHAIN_CODE)))
-        .ifPresent(o -> {
-          String chainCode = ((UnicodeString) o).getString();
-          accountIdentifierMetadata.setChainCode(chainCode);
+    }
+    /**
+     * Filling the status field of the Operation object from the cbor MAP  if not null.
+     * Accessed through {@value Constants#STATUS}
+     * @param operationMap The map containing the status field
+     * @param operation The Operation object to fill
+     */
+    private static void addStatusToOperation(Map operationMap, Operation operation) {
+        Optional.ofNullable(operationMap.get(key(Constants.STATUS))).ifPresent(o -> {
+            String status = ((UnicodeString) o).getString();
+            operation.setStatus(status);
         });
-  }
+    }
 
-  /**
-   * Filling the address field of the AccountIdentifier object from the cbor MAP  if not null.
-   * Accessed through {@value Constants#ADDRESS}
-   * @param accountIdentifierMap The map containing the address field
-   * @param accountIdentifier The AccountIdentifier object to fill
-   */
-  private static void addAddressToAccountIdentifier(Map accountIdentifierMap, AccountIdentifier accountIdentifier) {
-    Optional.ofNullable(accountIdentifierMap.get(key(Constants.ADDRESS)))
-        .ifPresent(o -> {
-          String address = ((UnicodeString) o).getString();
-          accountIdentifier.setAddress(address);
+    /**
+     * Adding an AccountIdentifier object populated from the cbor MAP  if not null.
+     * Accessed through {@value Constants#ACCOUNT}
+     * @param operationMap The map containing the account field
+     * @param operation The Operation object to fill
+     */
+    private static void addAccountIdentifierToOperation(Map operationMap, Operation operation) {
+        Optional.ofNullable(operationMap.get(key(Constants.ACCOUNT))).ifPresent(o -> {
+            Map accountIdentifierMap = (Map) o;
+            AccountIdentifier accountIdentifier = new AccountIdentifier();
+            // fill object
+            addAddressToAccountIdentifier(accountIdentifierMap, accountIdentifier);
+            addSubAccountToAccountIdentifier(accountIdentifierMap, accountIdentifier);
+            addMetaDataToAccountIdentifier(accountIdentifierMap, accountIdentifier);
+            // write to Operation
+            operation.setAccount(accountIdentifier);
         });
-  }
+    }
 
-  /**
-   * Adding a Sub accountIdentifier to the AccountIdentifier if not null.
-   * Accessed through {@value Constants#SUB_ACCOUNT}
-   * @param accountIdentifierMap The map containing the subAccount field
-   * @param accountIdentifier The AccountIdentifier object to fill
-   */
-  private static void addSubAccountToAccountIdentifier(Map accountIdentifierMap, AccountIdentifier accountIdentifier) {
-    Optional.ofNullable(accountIdentifierMap.get(key(Constants.SUB_ACCOUNT)))
-        .ifPresent(o -> {
-          Map subAccountIdentifierMap = (Map) o;
-          SubAccountIdentifier subAccountIdentifier = new SubAccountIdentifier();
-          // fill object
-          addAddressToSubAccountIdentifier(subAccountIdentifierMap, subAccountIdentifier);
-          // write to AccountIdentifier
-          accountIdentifier.setSubAccount(subAccountIdentifier);
+    /**
+     * Adding Metadata to the AccountIdentifier from the cbor MAP  if not null.
+     * Accessed through {@value Constants#METADATA}
+     * @param accountIdentifierMap The map containing the amount field
+     * @param accountIdentifier The Operation object to fill
+     */
+    private static void addMetaDataToAccountIdentifier(Map accountIdentifierMap, AccountIdentifier accountIdentifier) {
+        Optional.ofNullable(accountIdentifierMap.get(key(Constants.METADATA)))
+                .ifPresent(o -> {
+                    Map accountIdentifierMetadataMap = (Map) o;
+                    AccountIdentifierMetadata accountIdentifierMetadata = new AccountIdentifierMetadata();
+                    // fill object
+                    addChainCodeToAccountIdentifierMetadata(accountIdentifierMetadataMap, accountIdentifierMetadata);
+                    // write to AccountIdentifier
+                    accountIdentifier.setMetadata(accountIdentifierMetadata);
+                });
+    }
+
+    /**
+     * Filling the ChainCode field of the AccountIdentifierMetadata object from the cbor MAP  if not null.
+     * Accessed through {@value Constants#CHAIN_CODE}
+     * @param accountIdentifierMetadataMap The map containing the chain code field
+     * @param accountIdentifierMetadata The AccountIdentifierMetadata object to fill
+     */
+    private static void addChainCodeToAccountIdentifierMetadata(Map accountIdentifierMetadataMap,
+                                                                AccountIdentifierMetadata accountIdentifierMetadata) {
+        Optional.ofNullable(accountIdentifierMetadataMap.get(key(Constants.CHAIN_CODE)))
+                .ifPresent(o -> {
+                    String chainCode = ((UnicodeString) o).getString();
+                    accountIdentifierMetadata.setChainCode(chainCode);
+                });
+    }
+
+    /**
+     * Filling the address field of the AccountIdentifier object from the cbor MAP  if not null.
+     * Accessed through {@value Constants#ADDRESS}
+     * @param accountIdentifierMap The map containing the address field
+     * @param accountIdentifier The AccountIdentifier object to fill
+     */
+    private static void addAddressToAccountIdentifier(Map accountIdentifierMap, AccountIdentifier accountIdentifier) {
+        Optional.ofNullable(accountIdentifierMap.get(key(Constants.ADDRESS)))
+                .ifPresent(o -> {
+                    String address = ((UnicodeString) o).getString();
+                    accountIdentifier.setAddress(address);
+                });
+    }
+
+    /**
+     * Adding a Sub accountIdentifier to the AccountIdentifier if not null.
+     * Accessed through {@value Constants#SUB_ACCOUNT}
+     * @param accountIdentifierMap The map containing the subAccount field
+     * @param accountIdentifier The AccountIdentifier object to fill
+     */
+    private static void addSubAccountToAccountIdentifier(Map accountIdentifierMap, AccountIdentifier accountIdentifier) {
+        Optional.ofNullable(accountIdentifierMap.get(key(Constants.SUB_ACCOUNT)))
+                .ifPresent(o -> {
+                    Map subAccountIdentifierMap = (Map) o;
+                    SubAccountIdentifier subAccountIdentifier = new SubAccountIdentifier();
+                    // fill object
+                    addAddressToSubAccountIdentifier(subAccountIdentifierMap, subAccountIdentifier);
+                    // write to AccountIdentifier
+                    accountIdentifier.setSubAccount(subAccountIdentifier);
+                });
+    }
+
+    /**
+     * Filling the address field of the SubAccountIdentifier object from the cbor MAP  if not null.
+     * Accessed through {@value Constants#ADDRESS}
+     * @param subAccountIdentifierMap The map containing the address field
+     * @param subAccountIdentifier The SubAccountIdentifier object to fill
+     */
+    private static void addAddressToSubAccountIdentifier(Map subAccountIdentifierMap,
+                                                         SubAccountIdentifier subAccountIdentifier) {
+        Optional.ofNullable(subAccountIdentifierMap.get(key(Constants.ADDRESS)))
+                .ifPresent(o1 -> {
+                    String addressSub = ((UnicodeString) o1).getString();
+                    subAccountIdentifier.setAddress(addressSub);
+                });
+    }
+
+    /**
+     * Add an Amount object to the Operation object from the cbor MAP  if not null.
+     * Accessed through {@value Constants#AMOUNT}
+     * @param operationMap The map containing the amount field
+     * @param operation The Operation object to fill
+     */
+    private static void addAmount(Map operationMap, Operation operation) {
+        Optional.ofNullable(operationMap.get(key(Constants.AMOUNT))).ifPresent(o -> {
+            Map amountMap = (Map) o;
+            Amount amount = getAmountFromMap(amountMap);
+            operation.setAmount(amount);
         });
-  }
+    }
 
-  /**
-   * Filling the address field of the SubAccountIdentifier object from the cbor MAP  if not null.
-   * Accessed through {@value Constants#ADDRESS}
-   * @param subAccountIdentifierMap The map containing the address field
-   * @param subAccountIdentifier The SubAccountIdentifier object to fill
-   */
-  private static void addAddressToSubAccountIdentifier(Map subAccountIdentifierMap,
-      SubAccountIdentifier subAccountIdentifier) {
-    Optional.ofNullable(subAccountIdentifierMap.get(key(Constants.ADDRESS)))
-        .ifPresent(o1 -> {
-          String addressSub = ((UnicodeString) o1).getString();
-          subAccountIdentifier.setAddress(addressSub);
+    /**
+     * Returns an Amount object populated from the cbor MAP  if not null.
+     * Containing the value and metadata fields. Accessed through {@value Constants#VALUE} and {@value Constants#METADATA}
+     * @param amountMap The map containing the amount field
+     * @return The populated Amount object
+     */
+    private static Amount getAmountFromMap(Map amountMap) {
+        Amount amount = new Amount();
+
+        Optional.ofNullable(amountMap).ifPresent(am -> {
+            addValueToAmount(am, amount);
+            addMetadataToAmount(am, amount);
+            addCurrencyToAmount(am, amount);
         });
-  }
 
-  /**
-   * Add an Amount object to the Operation object from the cbor MAP  if not null.
-   * Accessed through {@value Constants#AMOUNT}
-   * @param operationMap The map containing the amount field
-   * @param operation The Operation object to fill
-   */
-  private static void addAmount(Map operationMap, Operation operation) {
-    Optional.ofNullable(operationMap.get(key(Constants.AMOUNT))).ifPresent(o -> {
-      Map amountMap = (Map) o;
-      Amount amount = getAmountFromMap(amountMap);
-      operation.setAmount(amount);
-    });
-  }
+        return amount;
+    }
 
-  /**
-   * Returns an Amount object populated from the cbor MAP  if not null.
-   * Containing the value and metadata fields. Accessed through {@value Constants#VALUE} and {@value Constants#METADATA}
-   * @param amountMap The map containing the amount field
-   * @return The populated Amount object
-   */
-  private static Amount getAmountFromMap(Map amountMap) {
-    Amount amount = new Amount();
-    Optional.ofNullable(amountMap).ifPresent(am -> {
-      addValueToAmount(am, amount);
-      addMetadataToAmount(am, amount);
-      addCurrencyToAmount(amountMap, amount);
-    });
-    return amount;
-  }
-
-  /**
-   * Add metadata to Amount object. The metadata object is accessed through {@value Constants#METADATA}.
-   * @param am The map containing the metadata field
-   * @param amount The Amount object to fill
-   */
-  private static void addMetadataToAmount(Map am, Amount amount) {
-    Optional.ofNullable(am.get(key(Constants.METADATA))).ifPresent(o -> {
-      Map metadataAm = (Map) o;
-      amount.setMetadata(metadataAm);
-    });
-  }
-
-  /**
-   * Add value to Amount object. The value is accessed through {@value Constants#VALUE}.
-   * @param am The map containing the value field
-   * @param amount The Amount object to fill
-   */
-  private static void addValueToAmount(Map am, Amount amount) {
-    Optional.ofNullable(am.get(key(Constants.VALUE))).ifPresent(o -> amount.setValue(((UnicodeString) o).getString()));
-  }
-
-
-  /**
-   * Add currency to the Amount object from the cbor MAP  if not null.
-   * Accessed through {@value Constants#CURRENCY}
-   * @param amountMap The map containing the amount field
-   * @param amount The Amount object to fill
-   */
-  private static void addCurrencyToAmount(Map amountMap, Amount amount) {
-    Optional.ofNullable(amountMap.get(key(Constants.CURRENCY))).ifPresent(o -> {
-      Map currencyMap = (Map) o;
-      Currency currency = getCurrencyMap(currencyMap);
-      addMetadataToCurrency(currencyMap, currency);
-      amount.setCurrency(currency);
-    });
-  }
-
-  /**
-   * Add Metadata to Currency populated from cbor MAP if not null. Metadata contains the policyID accessed through {@value Constants#POLICYID}
-   * @param currencyMap The map containing the currency field
-   * @param currency The Currency object to fill
-   */
-  private static void addMetadataToCurrency(Map currencyMap, Currency currency) {
-    Optional.ofNullable(currencyMap.get(key(Constants.METADATA))).ifPresent(o -> {
-      CurrencyMetadata metadata = new CurrencyMetadata();
-      Map addedMetadataMap = (Map) o;
-      addPolicyIdToMetadata(addedMetadataMap, metadata);
-      currency.setMetadata(metadata);
-    });
-  }
-
-  /**
-   * Add PolicyId to CurrencyMetadata object. The policyId is accessed through {@value Constants#POLICYID}
-   * @param addedMetadataMap The map containing the metadata field
-   * @param metadata The CurrencyMetadata object to fill
-   */
-  private static void addPolicyIdToMetadata(Map addedMetadataMap, CurrencyMetadata metadata) {
-    Optional.ofNullable(addedMetadataMap.get(key(Constants.POLICYID)))
-        .ifPresent(o -> metadata.setPolicyId(((UnicodeString) o).getString()));
-  }
-
-  /**
-   * Returns a Currency object populated from the cbor MAP  if not null.
-   * Containing the symbol and decimals fields. Accessed through {@value Constants#SYMBOL} and {@value Constants#DECIMALS}
-   * @param currencyMap The map containing the currency field
-   * @return The populated Currency object
-   */
-  private static Currency getCurrencyMap(Map currencyMap) {
-    Currency currency = new Currency();
-    Optional.ofNullable(currencyMap.get(key(Constants.SYMBOL))).ifPresent(o1 -> currency.setSymbol(((UnicodeString) o1).getString()));
-    Optional.ofNullable(currencyMap.get(key(Constants.DECIMALS))).ifPresent(o1 -> currency.setDecimals(((UnsignedInteger) o1).getValue().intValue()));
-    return currency;
-  }
-
-  /**
-   * Add Coin change to Operation. The Coin change objects is accessed through {@value Constants#COIN_CHANGE}.
-   * The Coin change object contains a CoinAction and a CoinIdentifier.
-   * @param operationMap The map containing the Coin change field
-   * @param operation The Operation object to fill
-   */
-  private static void addCoinChange(Map operationMap, Operation operation) {
-    Optional.ofNullable(operationMap.get(key(Constants.COIN_CHANGE))).ifPresent(o -> {
-      Map coinChangeMap = (Map) o;
-      CoinChange coinChange = new CoinChange();
-      addCoinActionToCoinChange(coinChangeMap, coinChange);
-      addCoinIdentifierToCoinChange(coinChangeMap, coinChange);
-      operation.setCoinChange(coinChange);
-    });
-  }
-
-  /**
-   * Add CoinIdentifier to CoinChange object. The coin identifier object is accessed through {@value Constants#COIN_IDENTIFIER}.
-   * @param coinChangeMap The map containing the coin identifier field
-   * @param coinChange The CoinChange object to fill
-   */
-  private static void addCoinIdentifierToCoinChange(Map coinChangeMap, CoinChange coinChange) {
-    Optional.ofNullable(coinChangeMap.get(key(Constants.COIN_IDENTIFIER)))
-        .ifPresent(o -> {
-          CoinIdentifier coinIdentifier = new CoinIdentifier();
-          Map coinIdentifierMap = (Map) o;
-          addIdentifierToCoinIdentifier(coinIdentifierMap, coinIdentifier);
-          coinChange.setCoinIdentifier(coinIdentifier);
+    /**
+     * Add metadata to Amount object. The metadata object is accessed through {@value Constants#METADATA}.
+     * @param am The map containing the metadata field
+     * @param amount The Amount object to fill
+     */
+    private static void addMetadataToAmount(Map am, Amount amount) {
+        Optional.ofNullable(am.get(key(Constants.METADATA))).ifPresent(o -> {
+            Map metadataAm = (Map) o;
+            amount.setMetadata(metadataAm);
         });
-  }
+    }
 
-  /**
-   * Add Identifier to CoinIdentifier object. The identifier is accessed through {@value Constants#IDENTIFIER}.
-   * @param coinIdentifierMap The map containing the identifier field
-   * @param coinIdentifier The CoinIdentifier object to fill
-   */
-  private static void addIdentifierToCoinIdentifier(Map coinIdentifierMap, CoinIdentifier coinIdentifier) {
-    Optional.ofNullable(coinIdentifierMap.get(key(Constants.IDENTIFIER)))
-        .ifPresent(o -> {
-          String identifier = ((UnicodeString) o).getString();
-          coinIdentifier.setIdentifier(identifier);
+    /**
+     * Add value to Amount object. The value is accessed through {@value Constants#VALUE}.
+     * @param am The map containing the value field
+     * @param amount The Amount object to fill
+     */
+    private static void addValueToAmount(Map am, Amount amount) {
+        Optional.ofNullable(am.get(key(Constants.VALUE))).ifPresent(o -> amount.setValue(((UnicodeString) o).getString()));
+    }
+
+
+    /**
+     * Add currency to the Amount object from the cbor MAP  if not null.
+     * Accessed through {@value Constants#CURRENCY}
+     * @param amountMap The map containing the amount field
+     * @param amount The Amount object to fill
+     */
+    private static void addCurrencyToAmount(Map amountMap, Amount amount) {
+        Optional.ofNullable(amountMap.get(key(Constants.CURRENCY))).ifPresent(o -> {
+            Map currencyMap = (Map) o;
+            Currency currency = getCurrencyMap(currencyMap);
+            addMetadataToCurrency(currencyMap, currency);
+            amount.setCurrency(currency);
         });
-  }
+    }
 
-  /**
-   * Add CoinAction to CoinChange object. The coin action is accessed through {@value Constants#COIN_ACTION}.
-   * @param coinChangeMap The map containing the coin action field
-   * @param coinChange The CoinChange object to fill
-   */
-  private static void addCoinActionToCoinChange(Map coinChangeMap, CoinChange coinChange) {
-    Optional.ofNullable(coinChangeMap.get(key(Constants.COIN_ACTION)))
-        .ifPresent(o -> {
-          String coinAction = ((UnicodeString) o).getString();
-          coinChange.setCoinAction(CoinAction.fromValue(coinAction));
+    /**
+     * Add Metadata to Currency populated from cbor MAP if not null. Metadata contains the policyID accessed through {@value Constants#POLICYID}
+     * @param currencyMap The map containing the currency field
+     * @param currency The Currency object to fill
+     */
+    private static void addMetadataToCurrency(Map currencyMap, Currency currency) {
+        Optional.ofNullable(currencyMap.get(key(Constants.METADATA))).ifPresent(o -> {
+            CurrencyMetadata metadata = new CurrencyMetadata();
+            Map addedMetadataMap = (Map) o;
+            addPolicyIdToMetadata(addedMetadataMap, metadata);
+            currency.setMetadata(metadata);
         });
-  }
+    }
 
-  /**
-   * Add metadata to Operation. The metadata object is accessed through {@value Constants#METADATA}.
-   * The metadata object contains a list of different metadata objects.
-   * @param operationMap The map containing the metadata field
-   * @param operation The Operation object to fill
-   */
-  private static void addMetadata(Map operationMap, Operation operation) {
-    Optional.ofNullable(operationMap.get(new UnicodeString(Constants.METADATA))).ifPresent(o -> {
-      Map metadataMap = (Map) operationMap.get(new UnicodeString(Constants.METADATA));
-      OperationMetadata operationMetadata = new OperationMetadata();
-      addWithdrawalAmount(metadataMap, operationMetadata);
-      addDepositAmount(metadataMap, operationMetadata);
-      addRefundAmount(metadataMap, operationMetadata);
-      addStakingCredential(metadataMap, operationMetadata);
-      addPoolKeyHash(metadataMap, operationMetadata);
-      addEpoch(metadataMap, operationMetadata);
-      addTokenBundle(metadataMap, operationMetadata);
-      addPoolRegistrationCert(metadataMap, operationMetadata);
-      addPoolRegistrationParams(metadataMap, operationMetadata);
-      addVoteRegistrationMetadata(metadataMap, operationMetadata);
-      operation.setMetadata(operationMetadata);
-    });
-  }
+    /**
+     * Add PolicyId to CurrencyMetadata object. The policyId is accessed through {@value Constants#POLICYID}
+     * @param addedMetadataMap The map containing the metadata field
+     * @param metadata The CurrencyMetadata object to fill
+     */
+    private static void addPolicyIdToMetadata(Map addedMetadataMap, CurrencyMetadata metadata) {
+        Optional.ofNullable(addedMetadataMap.get(key(Constants.POLICYID)))
+                .ifPresent(o -> metadata.setPolicyId(((UnicodeString) o).getString()));
+    }
 
-  /**
-   * Add a vote registration metadata to Operation object. The vote registration metadata object is accessed through {@value Constants#VOTEREGISTRATIONMETADATA}.
-   * The vote registration metadata object contains a list of different metadata objects.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addVoteRegistrationMetadata(Map metadataMap,
-      OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.VOTEREGISTRATIONMETADATA)))
-        .ifPresent(voteRegMetadata -> {
-          VoteRegistrationMetadata voteRegistrationMetadata = new VoteRegistrationMetadata();
-          Map voteRegistrationMetadataMap = (Map) metadataMap.get(key(Constants.VOTEREGISTRATIONMETADATA));
-          // filling the voteRegistrationMetadata object
-          addStakeKeyToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
-          addVoteKeyToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
-          addRewardAddressToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
-          addVoteSignatureToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
-          addVoteNonceToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
-          // write back to operation
-          operationMetadata.setVoteRegistrationMetadata(voteRegistrationMetadata);
+    /**
+     * Returns a Currency object populated from the cbor MAP  if not null.
+     * Containing the symbol and decimals fields. Accessed through {@value Constants#SYMBOL} and {@value Constants#DECIMALS}
+     * @param currencyMap The map containing the currency field
+     * @return The populated Currency object
+     */
+    private static Currency getCurrencyMap(Map currencyMap) {
+        Currency currency = new Currency();
+        Optional.ofNullable(currencyMap.get(key(Constants.SYMBOL))).ifPresent(o1 -> currency.setSymbol(((UnicodeString) o1).getString()));
+        Optional.ofNullable(currencyMap.get(key(Constants.DECIMALS))).ifPresent(o1 -> currency.setDecimals(((UnsignedInteger) o1).getValue().intValue()));
+        return currency;
+    }
+
+    /**
+     * Add Coin change to Operation. The Coin change objects is accessed through {@value Constants#COIN_CHANGE}.
+     * The Coin change object contains a CoinAction and a CoinIdentifier.
+     * @param operationMap The map containing the Coin change field
+     * @param operation The Operation object to fill
+     */
+    private static void addCoinChange(Map operationMap, Operation operation) {
+        Optional.ofNullable(operationMap.get(key(Constants.COIN_CHANGE))).ifPresent(o -> {
+            Map coinChangeMap = (Map) o;
+            CoinChange coinChange = new CoinChange();
+            addCoinActionToCoinChange(coinChangeMap, coinChange);
+            addCoinIdentifierToCoinChange(coinChangeMap, coinChange);
+            operation.setCoinChange(coinChange);
         });
-  }
+    }
 
-  /**
-   * Add Nonce to VoteMetadata object. The nonce is accessed through {@value Constants#VOTING_NONCE}.
-   * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
-   * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
-   */
-  private static void addVoteNonceToVoteMetadata(Map voteRegistrationMetadataMap,
-      VoteRegistrationMetadata voteRegistrationMetadata) {
-    Optional.ofNullable(
-            voteRegistrationMetadataMap.get(key(Constants.VOTING_NONCE)))
-        .ifPresent(votingNonce -> {
-          int votingNonceInt = ((UnsignedInteger) votingNonce).getValue().intValue();
-          voteRegistrationMetadata.setVotingNonce(votingNonceInt);
+    /**
+     * Add CoinIdentifier to CoinChange object. The coin identifier object is accessed through {@value Constants#COIN_IDENTIFIER}.
+     * @param coinChangeMap The map containing the coin identifier field
+     * @param coinChange The CoinChange object to fill
+     */
+    private static void addCoinIdentifierToCoinChange(Map coinChangeMap, CoinChange coinChange) {
+        Optional.ofNullable(coinChangeMap.get(key(Constants.COIN_IDENTIFIER)))
+                .ifPresent(o -> {
+                    CoinIdentifier coinIdentifier = new CoinIdentifier();
+                    Map coinIdentifierMap = (Map) o;
+                    addIdentifierToCoinIdentifier(coinIdentifierMap, coinIdentifier);
+                    coinChange.setCoinIdentifier(coinIdentifier);
+                });
+    }
+
+    /**
+     * Add Identifier to CoinIdentifier object. The identifier is accessed through {@value Constants#IDENTIFIER}.
+     * @param coinIdentifierMap The map containing the identifier field
+     * @param coinIdentifier The CoinIdentifier object to fill
+     */
+    private static void addIdentifierToCoinIdentifier(Map coinIdentifierMap, CoinIdentifier coinIdentifier) {
+        Optional.ofNullable(coinIdentifierMap.get(key(Constants.IDENTIFIER)))
+                .ifPresent(o -> {
+                    String identifier = ((UnicodeString) o).getString();
+                    coinIdentifier.setIdentifier(identifier);
+                });
+    }
+
+    /**
+     * Add CoinAction to CoinChange object. The coin action is accessed through {@value Constants#COIN_ACTION}.
+     * @param coinChangeMap The map containing the coin action field
+     * @param coinChange The CoinChange object to fill
+     */
+    private static void addCoinActionToCoinChange(Map coinChangeMap, CoinChange coinChange) {
+        Optional.ofNullable(coinChangeMap.get(key(Constants.COIN_ACTION)))
+                .ifPresent(o -> {
+                    String coinAction = ((UnicodeString) o).getString();
+                    coinChange.setCoinAction(CoinAction.fromValue(coinAction));
+                });
+    }
+
+    /**
+     * Add metadata to Operation. The metadata object is accessed through {@value Constants#METADATA}.
+     * The metadata object contains a list of different metadata objects.
+     * @param operationMap The map containing the metadata field
+     * @param operation The Operation object to fill
+     */
+    private static void addMetadata(Map operationMap, Operation operation) {
+        Optional.ofNullable(operationMap.get(new UnicodeString(Constants.METADATA))).ifPresent(o -> {
+            Map metadataMap = (Map) operationMap.get(new UnicodeString(Constants.METADATA));
+            OperationMetadata operationMetadata = new OperationMetadata();
+            addWithdrawalAmount(metadataMap, operationMetadata);
+            addDepositAmount(metadataMap, operationMetadata);
+            addRefundAmount(metadataMap, operationMetadata);
+            addStakingCredential(metadataMap, operationMetadata);
+            addPoolKeyHash(metadataMap, operationMetadata);
+            addEpoch(metadataMap, operationMetadata);
+            addTokenBundle(metadataMap, operationMetadata);
+            addPoolRegistrationCert(metadataMap, operationMetadata);
+            addPoolRegistrationParams(metadataMap, operationMetadata);
+            addVoteRegistrationMetadata(metadataMap, operationMetadata);
+
+            operation.setMetadata(operationMetadata);
         });
-  }
+    }
 
-  /**
-   * Add Signature to VoteMetadata object. The signature is accessed through {@value Constants#VOTING_SIGNATURE}.
-   * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
-   * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
-   */
-  private static void addVoteSignatureToVoteMetadata(Map voteRegistrationMetadataMap,
-      VoteRegistrationMetadata voteRegistrationMetadata) {
-    Optional.ofNullable(
-            voteRegistrationMetadataMap.get(key(Constants.VOTING_SIGNATURE)))
-        .ifPresent(votingSignature -> {
-          String votingSignatureStr = ((UnicodeString) votingSignature).getString();
-          voteRegistrationMetadata.setVotingSignature(votingSignatureStr);
+    /**
+     * Add a vote registration metadata to Operation object. The vote registration metadata object is accessed through {@value Constants#VOTEREGISTRATIONMETADATA}.
+     * The vote registration metadata object contains a list of different metadata objects.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addVoteRegistrationMetadata(Map metadataMap,
+                                                    OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.VOTEREGISTRATIONMETADATA)))
+                .ifPresent(voteRegMetadata -> {
+                    VoteRegistrationMetadata voteRegistrationMetadata = new VoteRegistrationMetadata();
+                    Map voteRegistrationMetadataMap = (Map) metadataMap.get(key(Constants.VOTEREGISTRATIONMETADATA));
+                    // filling the voteRegistrationMetadata object
+                    addStakeKeyToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
+                    addVoteKeyToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
+                    addRewardAddressToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
+                    addVoteSignatureToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
+                    addVoteNonceToVoteMetadata(voteRegistrationMetadataMap, voteRegistrationMetadata);
+                    // write back to operation
+                    operationMetadata.setVoteRegistrationMetadata(voteRegistrationMetadata);
+                });
+    }
+
+    /**
+     * Add Nonce to VoteMetadata object. The nonce is accessed through {@value Constants#VOTING_NONCE}.
+     * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
+     * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
+     */
+    private static void addVoteNonceToVoteMetadata(Map voteRegistrationMetadataMap,
+                                                   VoteRegistrationMetadata voteRegistrationMetadata) {
+        Optional.ofNullable(
+                        voteRegistrationMetadataMap.get(key(Constants.VOTING_NONCE)))
+                .ifPresent(votingNonce -> {
+                    int votingNonceInt = ((UnsignedInteger) votingNonce).getValue().intValue();
+                    voteRegistrationMetadata.setVotingNonce(votingNonceInt);
+                });
+    }
+
+    /**
+     * Add Signature to VoteMetadata object. The signature is accessed through {@value Constants#VOTING_SIGNATURE}.
+     * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
+     * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
+     */
+    private static void addVoteSignatureToVoteMetadata(Map voteRegistrationMetadataMap,
+                                                       VoteRegistrationMetadata voteRegistrationMetadata) {
+        Optional.ofNullable(
+                        voteRegistrationMetadataMap.get(key(Constants.VOTING_SIGNATURE)))
+                .ifPresent(votingSignature -> {
+                    String votingSignatureStr = ((UnicodeString) votingSignature).getString();
+                    voteRegistrationMetadata.setVotingSignature(votingSignatureStr);
+                });
+    }
+
+    /**
+     * Add Reward address to VoteMetadata object. The reward address is accessed through {@value Constants#REWARD_ADDRESS}.
+     * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
+     * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
+     */
+    private static void addRewardAddressToVoteMetadata(Map voteRegistrationMetadataMap,
+                                                       VoteRegistrationMetadata voteRegistrationMetadata) {
+        Optional.ofNullable(
+                        voteRegistrationMetadataMap.get(new UnicodeString(Constants.REWARD_ADDRESS)))
+                .ifPresent(rewardAddress -> {
+                    String rewardAddress2 = ((UnicodeString) rewardAddress).getString();
+                    voteRegistrationMetadata.setRewardAddress(rewardAddress2);
+                });
+    }
+
+    /**
+     * Add VoteKey key to VoteMetadata object. The stake key is accessed through {@value Constants#VOTING_KEY}.
+     * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
+     * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
+     */
+    private static void addVoteKeyToVoteMetadata(Map voteRegistrationMetadataMap,
+                                                 VoteRegistrationMetadata voteRegistrationMetadata) {
+        Optional.ofNullable(
+                        voteRegistrationMetadataMap.get(new UnicodeString(Constants.VOTING_KEY)))
+                .ifPresent(votingKey -> {
+                    Map votingKeyMap = (Map) votingKey;
+                    PublicKey publicKey2 = getPublicKeyFromMap(votingKeyMap);
+                    voteRegistrationMetadata.setVotingkey(publicKey2);
+                });
+    }
+
+    /**
+     * Add StakeKey to VoteMetadata object. The stake key is accessed through {@value Constants#STAKE_KEY}.
+     * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
+     * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
+     */
+    private static void addStakeKeyToVoteMetadata(Map voteRegistrationMetadataMap,
+                                                  VoteRegistrationMetadata voteRegistrationMetadata) {
+        Optional.ofNullable(
+                        voteRegistrationMetadataMap.get(new UnicodeString(Constants.STAKE_KEY)))
+                .ifPresent(stakeKey -> {
+                    Map stakeKeyMap = (Map) stakeKey;
+                    PublicKey publicKey1 = getPublicKeyFromMap(stakeKeyMap);
+                    voteRegistrationMetadata.setStakeKey(publicKey1);
+                });
+    }
+
+    /**
+     * Add PoolRegistrationParams to Operation metadata object. The pool registration params object is accessed through {@value Constants#POOLREGISTRATIONPARAMS}.
+     * The pool registration params object contains a list of different metadata objects.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addPoolRegistrationParams(Map metadataMap,
+                                                  OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.POOLREGISTRATIONPARAMS)))
+                .ifPresent(poolMap -> {
+                    Map poolRegistrationParamsMap = (Map) poolMap;
+                    PoolRegistrationParams poolRegistrationParams = new PoolRegistrationParams();
+                    // filling the poolRegistrationParams object
+                    addVrfKeyHash(poolRegistrationParamsMap, poolRegistrationParams);
+                    addRewardAddress(poolRegistrationParamsMap, poolRegistrationParams);
+                    addPledge(poolRegistrationParamsMap, poolRegistrationParams);
+                    addCost(poolRegistrationParamsMap, poolRegistrationParams);
+                    addPoolOwners(poolRegistrationParamsMap, poolRegistrationParams);
+                    addRelays(poolRegistrationParamsMap, poolRegistrationParams);
+                    addMargins(poolRegistrationParamsMap, poolRegistrationParams);
+                    addMarginPercentage(poolRegistrationParamsMap, poolRegistrationParams);
+                    addPoolMetadata(poolRegistrationParamsMap, poolRegistrationParams);
+                    // write back to operation metadata
+                    operationMetadata.setPoolRegistrationParams(poolRegistrationParams);
+                });
+    }
+
+    /**
+     * Add PoolMetadata to Evapotranspirations object. The pool metadata object is accessed through {@value Constants#POOLMETADATA}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    private static void addPoolMetadata(Map poolRegistrationParamsMap,
+                                        PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.POOLMETADATA)))
+                .ifPresent(pMap -> {
+                    PoolMetadata poolMetadata = new PoolMetadata();
+                    Map poolMetadataMap = (Map) pMap;
+                    // filling the poolMetadata object
+                    addUrlToPoolMetadata(poolMetadataMap, poolMetadata);
+                    addHashToPoolMetadata(poolMetadataMap, poolMetadata);
+                    // write back to poolRegistrationParams
+                    poolRegistrationParams.setPoolMetadata(poolMetadata);
+                });
+    }
+
+    /**
+     * Add Hash to Pool Metadata Map object. The hash is accessed through {@value Constants#HASH}.
+     * @param poolMetadataMap The map containing the pool metadata field
+     * @param poolMetadata The PoolMetadata object to fill
+     */
+    private static void addHashToPoolMetadata(Map poolMetadataMap, PoolMetadata poolMetadata) {
+        Optional.ofNullable(poolMetadataMap.get(key(Constants.HASH)))
+                .ifPresent(hash -> {
+                    String hashStr = ((UnicodeString) hash).getString();
+                    poolMetadata.setHash(hashStr);
+                });
+    }
+
+    /**
+     * Add Url to Pool Metadata Object from the cbor MAP  if not null.
+     * Accessed through {@value Constants#URL}
+     * @param poolMetadataMap The map containing the pool metadata field
+     * @param poolMetadata The PoolMetadata object to fill
+     */
+    private static void addUrlToPoolMetadata(Map poolMetadataMap, PoolMetadata poolMetadata) {
+        Optional.ofNullable(poolMetadataMap.get(key(Constants.URL)))
+                .ifPresent(url -> {
+                    String urlStr = ((UnicodeString) url).getString();
+                    poolMetadata.setUrl(urlStr);
+                });
+    }
+
+    /**
+     * Add Margin Percentage to Pool registration params object. The margin percentage is accessed through {@value Constants#MARGIN_PERCENTAGE}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    private static void addMarginPercentage(Map poolRegistrationParamsMap,
+                                            PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.MARGIN_PERCENTAGE)))
+                .ifPresent(percentage -> {
+                    String marginPercentage = ((UnicodeString) percentage).getString();
+                    poolRegistrationParams.setMarginPercentage(marginPercentage);
+                });
+    }
+
+    /**
+     * Add Margins to Pool registration params object. The margin object is accessed through {@value Constants#MARGIN}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    private static void addMargins(Map poolRegistrationParamsMap,
+                                   PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(poolRegistrationParamsMap.get(new UnicodeString(Constants.MARGIN)))
+                .ifPresent(o -> {
+                    Map marginMap = (Map) o;
+                    PoolMargin poolMargin = new PoolMargin();
+                    // filling the poolMargin object
+                    addNumeratorToPoolMargin(marginMap, poolMargin);
+                    addDenominatorToPoolMargin(marginMap, poolMargin);
+                    // write back to poolRegistrationParams
+                    poolRegistrationParams.setMargin(poolMargin);
+                });
+    }
+
+    /**
+     * Add Denominator to Pool margin object. The denominator is accessed through {@value Constants#DENOMINATOR}.
+     * @param marginMap The map containing the margin field
+     * @param poolMargin The PoolMargin object to fill
+     */
+    private static void addDenominatorToPoolMargin(Map marginMap, PoolMargin poolMargin) {
+        Optional.ofNullable(marginMap.get(new UnicodeString(Constants.DENOMINATOR)))
+                .ifPresent(o -> {
+                    String denominator = ((UnicodeString) o).getString();
+                    poolMargin.setDenominator(denominator);
+                });
+    }
+
+    /**
+     * Add Numerator to Pool margin object. The numerator is accessed through {@value Constants#NUMERATOR}.
+     * @param marginMap The map containing the margin field
+     * @param poolMargin The PoolMargin object to fill
+     */
+    private static void addNumeratorToPoolMargin(Map marginMap, PoolMargin poolMargin) {
+        Optional.ofNullable(marginMap.get(new UnicodeString(Constants.NUMERATOR)))
+                .ifPresent(o -> {
+                    String numerator = ((UnicodeString) o).getString();
+                    poolMargin.setNumerator(numerator);
+                });
+    }
+
+    /**
+     * Adding Relays to PoolRegistrationParams object. The relays object is accessed through {@value Constants#RELAYS}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    private static void addRelays(Map poolRegistrationParamsMap,
+                                  PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(
+                        ((Array) poolRegistrationParamsMap.get(new UnicodeString(Constants.RELAYS))).getDataItems())
+                .ifPresent(o -> {
+                    List<Relay> relayList = new ArrayList<>();
+                    List<DataItem> relaysArray = ((Array) poolRegistrationParamsMap.get(
+                            new UnicodeString(Constants.RELAYS))).getDataItems();
+                    relaysArray.forEach(rA -> {
+                        Map rAMap = (Map) rA;
+                        Relay relay = new Relay();
+                        addRelayType(rAMap, relay);
+                        addIpv4(rAMap, relay);
+                        addIpv6(rAMap, relay);
+                        addDnsName(rAMap, relay);
+                        relayList.add(relay);
+                    });
+                    poolRegistrationParams.setRelays(relayList);
+                });
+    }
+
+    /** Add DnsName to Relay object. The DnsName is accessed through {@value Constants#DNSNAME}.
+     * @param rAMap The map containing the relay field
+     * @param relay The Relay object to fill
+     */
+    private static void addDnsName(Map rAMap, Relay relay) {
+        Optional.ofNullable(rAMap.get(new UnicodeString(Constants.DNSNAME))).ifPresent(o -> {
+            String dnsName = ((UnicodeString) o).getString();
+            relay.setDnsName(dnsName);
         });
-  }
+    }
 
-  /**
-   * Add Reward address to VoteMetadata object. The reward address is accessed through {@value Constants#REWARD_ADDRESS}.
-   * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
-   * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
-   */
-  private static void addRewardAddressToVoteMetadata(Map voteRegistrationMetadataMap,
-      VoteRegistrationMetadata voteRegistrationMetadata) {
-    Optional.ofNullable(
-            voteRegistrationMetadataMap.get(new UnicodeString(Constants.REWARD_ADDRESS)))
-        .ifPresent(rewardAddress -> {
-          String rewardAddress2 = ((UnicodeString) rewardAddress).getString();
-          voteRegistrationMetadata.setRewardAddress(rewardAddress2);
+    /**
+     * Add IPv6 to Relay object. The IPv6 is accessed through {@value Constants#IPV6}.
+     * @param rAMap The map containing the relay field
+     * @param relay The Relay object to fill
+     */
+    private static void addIpv6(Map rAMap, Relay relay) {
+        Optional.ofNullable(rAMap.get(new UnicodeString(Constants.IPV6))).ifPresent(o -> {
+            String ipv6 = ((UnicodeString) o).getString();
+            relay.setIpv6(ipv6);
         });
-  }
+    }
 
-  /**
-   * Add VoteKey key to VoteMetadata object. The stake key is accessed through {@value Constants#VOTING_KEY}.
-   * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
-   * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
-   */
-  private static void addVoteKeyToVoteMetadata(Map voteRegistrationMetadataMap,
-      VoteRegistrationMetadata voteRegistrationMetadata) {
-    Optional.ofNullable(
-            voteRegistrationMetadataMap.get(new UnicodeString(Constants.VOTING_KEY)))
-        .ifPresent(votingKey -> {
-          Map votingKeyMap = (Map) votingKey;
-          PublicKey publicKey2 = getPublicKeyFromMap(votingKeyMap);
-          voteRegistrationMetadata.setVotingkey(publicKey2);
+    /**
+     * Add IPv4 to Relay object. The IPv4 is accessed through {@value Constants#IPV4}.
+     * @param rAMap The map containing the relay field
+     * @param relay The Relay object to fill
+     */
+    private static void addIpv4(Map rAMap, Relay relay) {
+        Optional.ofNullable(rAMap.get(new UnicodeString(Constants.IPV4))).ifPresent(o -> {
+            String ipv4 = ((UnicodeString) o).getString();
+            relay.setIpv4(ipv4);
         });
-  }
+    }
 
-  /**
-   * Add StakeKey to VoteMetadata object. The stake key is accessed through {@value Constants#STAKE_KEY}.
-   * @param voteRegistrationMetadataMap The map containing the vote registration metadata field
-   * @param voteRegistrationMetadata The VoteRegistrationMetadata object to fill
-   */
-  private static void addStakeKeyToVoteMetadata(Map voteRegistrationMetadataMap,
-      VoteRegistrationMetadata voteRegistrationMetadata) {
-    Optional.ofNullable(
-            voteRegistrationMetadataMap.get(new UnicodeString(Constants.STAKE_KEY)))
-        .ifPresent(stakeKey -> {
-          Map stakeKeyMap = (Map) stakeKey;
-          PublicKey publicKey1 = getPublicKeyFromMap(stakeKeyMap);
-          voteRegistrationMetadata.setStakeKey(publicKey1);
+    /**
+     * Add Type to Relay object. The type is accessed through {@value Constants#TYPE}.
+     * @param rAMap The map containing the relay field
+     * @param relay The Relay object to fill
+     */
+    private static void addRelayType(Map rAMap, Relay relay) {
+        Optional.ofNullable(rAMap.get(new UnicodeString(Constants.TYPE))).ifPresent(o -> {
+            String typeR = ((UnicodeString) rAMap.get(new UnicodeString(Constants.TYPE))).getString();
+            relay.setType(typeR);
         });
-  }
+    }
 
-  /**
-   * Add PoolRegistrationParams to Operation metadata object. The pool registration params object is accessed through {@value Constants#POOLREGISTRATIONPARAMS}.
-   * The pool registration params object contains a list of different metadata objects.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addPoolRegistrationParams(Map metadataMap,
-      OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.POOLREGISTRATIONPARAMS)))
-        .ifPresent(poolMap -> {
-          Map poolRegistrationParamsMap = (Map) poolMap;
-          PoolRegistrationParams poolRegistrationParams = new PoolRegistrationParams();
-          // filling the poolRegistrationParams object
-          addVrfKeyHash(poolRegistrationParamsMap, poolRegistrationParams);
-          addRewardAddress(poolRegistrationParamsMap, poolRegistrationParams);
-          addPledge(poolRegistrationParamsMap, poolRegistrationParams);
-          addCost(poolRegistrationParamsMap, poolRegistrationParams);
-          addPoolOwners(poolRegistrationParamsMap, poolRegistrationParams);
-          addRelays(poolRegistrationParamsMap, poolRegistrationParams);
-          addMargins(poolRegistrationParamsMap, poolRegistrationParams);
-          addMarginPercentage(poolRegistrationParamsMap, poolRegistrationParams);
-          addPoolMetadata(poolRegistrationParamsMap, poolRegistrationParams);
-          // write back to operation metadata
-          operationMetadata.setPoolRegistrationParams(poolRegistrationParams);
+    /**
+     * Add a List of PoolOwners to Pool registration params object. The pool owners are accessed through {@value Constants#POOLOWNERS}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    private static void addPoolOwners(Map poolRegistrationParamsMap,
+                                      PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.POOLOWNERS)))
+                .ifPresent(o -> {
+                    List<String> stringList = new ArrayList<>();
+                    List<DataItem> poolOwners = ((Array) o).getDataItems();
+                    poolOwners.forEach(p -> {
+                        if (p != null) {
+                            stringList.add(((UnicodeString) p).getString());
+                        }
+                    });
+                    poolRegistrationParams.setPoolOwners(stringList);
+                });
+    }
+
+    /**
+     * Add Cost to Pool registration params object. The cost is accessed through {@value Constants#COST}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    private static void addCost(Map poolRegistrationParamsMap,
+                                PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.COST)))
+                .ifPresent(o -> {
+                    String cost = ((UnicodeString) o).getString();
+                    poolRegistrationParams.setCost(cost);
+                });
+    }
+
+    /**
+     * Add Pledge to Pool registration params object. The pledge is accessed through {@value Constants#PLEDGE}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    private static void addPledge(Map poolRegistrationParamsMap,
+                                  PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.PLEDGE)))
+                .ifPresent(o -> {
+                    String pledge = ((UnicodeString) o).getString();
+                    poolRegistrationParams.setPledge(pledge);
+                });
+    }
+
+    /**
+     * Add RewardAddress to Pool registration params object. The reward address is accessed through {@value Constants#REWARD_ADDRESS}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    private static void addRewardAddress(Map poolRegistrationParamsMap,
+                                         PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.REWARD_ADDRESS)))
+                .ifPresent(o -> {
+                    String rewardAddress = ((UnicodeString) o).getString();
+                    poolRegistrationParams.setRewardAddress(rewardAddress);
+                });
+    }
+
+    /**
+     * Add VrfKeyHash to Pool registration params object. The vrf key hash is accessed through {@value Constants#VRFKEYHASH}.
+     * @param poolRegistrationParamsMap The map containing the pool registration params field
+     * @param poolRegistrationParams The PoolRegistrationParams object to fill
+     */
+    public static void addVrfKeyHash(Map poolRegistrationParamsMap,
+                                     PoolRegistrationParams poolRegistrationParams) {
+        Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.VRFKEYHASH)))
+                .ifPresent(o -> {
+                    String vrfKeyHash = ((UnicodeString) o).getString();
+                    poolRegistrationParams.setVrfKeyHash(vrfKeyHash);
+                });
+    }
+
+    /**
+     * Add PoolRegistrationCert to Operation Metadata object. The pool registration cert is accessed through {@value Constants#POOLREGISTRATIONCERT}.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addPoolRegistrationCert(Map metadataMap,
+                                                OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.POOLREGISTRATIONCERT)))
+                .ifPresent(o -> {
+                    String poolRegistrationCert = ((UnicodeString) o).getString();
+                    operationMetadata.setPoolRegistrationCert(poolRegistrationCert);
+                });
+    }
+
+    /**
+     * Add TokenBundle to Operation metadata object. The token bundle is accessed through {@value Constants#TOKENBUNDLE}.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addTokenBundle(Map metadataMap, OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.TOKENBUNDLE))).ifPresent(o -> {
+            List<DataItem> tokenBundleArray = ((Array) o).getDataItems();
+            List<TokenBundleItem> tokenBundleItems = new ArrayList<>();
+            tokenBundleArray.forEach(t -> {
+                Map tokenBundleMap = (Map) t;
+                TokenBundleItem tokenBundleItem = new TokenBundleItem();
+                // fill object
+                addPolicyIdToTokenBundleItem(tokenBundleMap, tokenBundleItem);
+                addTokensToTokenBundleItem(tokenBundleMap, tokenBundleItem);
+                // write back to tokenBundleItems
+                tokenBundleItems.add(tokenBundleItem);
+            });
+            operationMetadata.setTokenBundle(tokenBundleItems);
         });
-  }
+    }
 
-  /**
-   * Add PoolMetadata to Evapotranspirations object. The pool metadata object is accessed through {@value Constants#POOLMETADATA}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  private static void addPoolMetadata(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.POOLMETADATA)))
-        .ifPresent(pMap -> {
-          PoolMetadata poolMetadata = new PoolMetadata();
-          Map poolMetadataMap = (Map) pMap;
-          // filling the poolMetadata object
-          addUrlToPoolMetadata(poolMetadataMap, poolMetadata);
-          addHashToPoolMetadata(poolMetadataMap, poolMetadata);
-          // write back to poolRegistrationParams
-          poolRegistrationParams.setPoolMetadata(poolMetadata);
+    /**
+     * Add Tokens to TokenBundleItem object. The tokens are accessed through {@value Constants#TOKENS}.
+     * @param tokenBundleMap The map containing the token bundle field
+     * @param tokenBundleItem The TokenBundleItem object to fill
+     */
+    private static void addTokensToTokenBundleItem(Map tokenBundleMap, TokenBundleItem tokenBundleItem) {
+        List<Amount> tokenAList = new ArrayList<>();
+        Optional.ofNullable(tokenBundleMap.get(key(Constants.TOKENS))).ifPresent(o -> {
+            List<DataItem> tokensItem = ((Array) o).getDataItems();
+            tokensItem.forEach(tk -> {
+                Map tokenAmountMap = (Map) tk;
+
+                Optional.ofNullable(tokenAmountMap.get(key(Constants.AMOUNT))).ifPresent(am -> {
+                    Map amountMap = (Map) am;
+                    Amount amount = getAmountFromMap(amountMap);
+
+                    tokenAList.add(amount);
+                });
+            });
         });
-  }
 
-  /**
-   * Add Hash to Pool Metadata Map object. The hash is accessed through {@value Constants#HASH}.
-   * @param poolMetadataMap The map containing the pool metadata field
-   * @param poolMetadata The PoolMetadata object to fill
-   */
-  private static void addHashToPoolMetadata(Map poolMetadataMap, PoolMetadata poolMetadata) {
-    Optional.ofNullable(poolMetadataMap.get(key(Constants.HASH)))
-        .ifPresent(hash -> {
-          String hashStr = ((UnicodeString) hash).getString();
-          poolMetadata.setHash(hashStr);
+        tokenBundleItem.setTokens(tokenAList);
+    }
+
+    /**
+     * Add PolicyId to TokenBundleItem object. The policyId is accessed
+     * @param tokenBundleMap The map containing the token bundle field
+     * @param tokenBundleItem The TokenBundleItem object to fill
+     */
+    private static void addPolicyIdToTokenBundleItem(Map tokenBundleMap, TokenBundleItem tokenBundleItem) {
+        Optional.ofNullable(tokenBundleMap.get(key(Constants.POLICYID))).ifPresent(o -> {
+            String policyId = ((UnicodeString) o).getString();
+            tokenBundleItem.setPolicyId(policyId);
         });
-  }
+    }
 
-  /**
-   * Add Url to Pool Metadata Object from the cbor MAP  if not null.
-   * Accessed through {@value Constants#URL}
-   * @param poolMetadataMap The map containing the pool metadata field
-   * @param poolMetadata The PoolMetadata object to fill
-   */
-  private static void addUrlToPoolMetadata(Map poolMetadataMap, PoolMetadata poolMetadata) {
-    Optional.ofNullable(poolMetadataMap.get(key(Constants.URL)))
-        .ifPresent(url -> {
-          String urlStr = ((UnicodeString) url).getString();
-          poolMetadata.setUrl(urlStr);
+    /**
+     * Add Epoch to Operation metadata object. The epoch is accessed through {@value Constants#EPOCH}.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addEpoch(Map metadataMap, OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.EPOCH))).ifPresent(o -> {
+            BigInteger value = ((UnsignedInteger) metadataMap.get(
+                    new UnicodeString(Constants.EPOCH))).getValue();
+            operationMetadata.setEpoch(value.intValue());
         });
-  }
+    }
 
-  /**
-   * Add Margin Percentage to Pool registration params object. The margin percentage is accessed through {@value Constants#MARGIN_PERCENTAGE}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  private static void addMarginPercentage(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.MARGIN_PERCENTAGE)))
-        .ifPresent(percentage -> {
-          String marginPercentage = ((UnicodeString) percentage).getString();
-          poolRegistrationParams.setMarginPercentage(marginPercentage);
+    /**
+     * Add PoolKeyHash to Operation metadata object. The pool key hash is accessed through {@value Constants#POOL_KEY_HASH}.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addPoolKeyHash(Map metadataMap, OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.POOL_KEY_HASH)))
+                .ifPresent(o -> operationMetadata.setPoolKeyHash(((UnicodeString) o).getString()));
+    }
+
+    /**
+     * Add StakingCredential to Operation metadata object. The staking credential is accessed through {@value Constants#STAKING_CREDENTIAL}.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addStakingCredential(Map metadataMap, OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.STAKING_CREDENTIAL)))
+                .ifPresent(o -> {
+                    Map stakingCredentialMap = (Map) o;
+                    operationMetadata.setStakingCredential(getPublicKeyFromMap(stakingCredentialMap));
+                });
+    }
+
+    /**
+     * Add RefundAmount to Operation metadata object. The refund amount is accessed through {@value Constants#REFUNDAMOUNT}.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addRefundAmount(Map metadataMap, OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.REFUNDAMOUNT))).ifPresent(o -> {
+            Map refundAmountMap = (Map) o;
+            operationMetadata.setRefundAmount(getAmountFromMap(refundAmountMap));
+
         });
-  }
+    }
 
-  /**
-   * Add Margins to Pool registration params object. The margin object is accessed through {@value Constants#MARGIN}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  private static void addMargins(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(poolRegistrationParamsMap.get(new UnicodeString(Constants.MARGIN)))
-        .ifPresent(o -> {
-          Map marginMap = (Map) o;
-          PoolMargin poolMargin = new PoolMargin();
-          // filling the poolMargin object
-          addNumeratorToPoolMargin(marginMap, poolMargin);
-          addDenominatorToPoolMargin(marginMap, poolMargin);
-          // write back to poolRegistrationParams
-          poolRegistrationParams.setMargin(poolMargin);
-        });
-  }
+    /**
+     * Add DepositAmount to Operation metadata object. The deposit amount is accessed through {@value Constants#DEPOSITAMOUNT}.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addDepositAmount(Map metadataMap, OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.DEPOSITAMOUNT)))
+                .ifPresent(o -> {
+                    Map depositAmountMap = (Map) o;
+                    Amount amountD = getAmountFromMap(depositAmountMap);
+                    operationMetadata.setDepositAmount(amountD);
+                });
+    }
 
-  /**
-   * Add Denominator to Pool margin object. The denominator is accessed through {@value Constants#DENOMINATOR}.
-   * @param marginMap The map containing the margin field
-   * @param poolMargin The PoolMargin object to fill
-   */
-  private static void addDenominatorToPoolMargin(Map marginMap, PoolMargin poolMargin) {
-    Optional.ofNullable(marginMap.get(new UnicodeString(Constants.DENOMINATOR)))
-        .ifPresent(o -> {
-          String denominator = ((UnicodeString) o).getString();
-          poolMargin.setDenominator(denominator);
-        });
-  }
+    /**
+     * Add WithdrawalAmount to Operation metadata object. The withdrawal amount is accessed through {@value Constants#WITHDRAWALAMOUNT}.
+     * @param metadataMap The map containing the metadata field
+     * @param operationMetadata The OperationMetadata object to fill
+     */
+    private static void addWithdrawalAmount(Map metadataMap, OperationMetadata operationMetadata) {
+        Optional.ofNullable(metadataMap.get(key(Constants.WITHDRAWALAMOUNT)))
+                .ifPresent(o -> {
+                    Map withdrawalAmountMap = (Map) o;
+                    Amount amountW = getAmountFromMap(withdrawalAmountMap);
+                    operationMetadata.setWithdrawalAmount(amountW);
+                });
+    }
 
-  /**
-   * Add Numerator to Pool margin object. The numerator is accessed through {@value Constants#NUMERATOR}.
-   * @param marginMap The map containing the margin field
-   * @param poolMargin The PoolMargin object to fill
-   */
-  private static void addNumeratorToPoolMargin(Map marginMap, PoolMargin poolMargin) {
-    Optional.ofNullable(marginMap.get(new UnicodeString(Constants.NUMERATOR)))
-        .ifPresent(o -> {
-          String numerator = ((UnicodeString) o).getString();
-          poolMargin.setNumerator(numerator);
-        });
-  }
-
-  /**
-   * Adding Relays to PoolRegistrationParams object. The relays object is accessed through {@value Constants#RELAYS}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  private static void addRelays(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(
-            ((Array) poolRegistrationParamsMap.get(new UnicodeString(Constants.RELAYS))).getDataItems())
-        .ifPresent(o -> {
-          List<Relay> relayList = new ArrayList<>();
-          List<DataItem> relaysArray = ((Array) poolRegistrationParamsMap.get(
-              new UnicodeString(Constants.RELAYS))).getDataItems();
-          relaysArray.forEach(rA -> {
-            Map rAMap = (Map) rA;
-            Relay relay = new Relay();
-            addRelayType(rAMap, relay);
-            addIpv4(rAMap, relay);
-            addIpv6(rAMap, relay);
-            addDnsName(rAMap, relay);
-            relayList.add(relay);
-          });
-          poolRegistrationParams.setRelays(relayList);
-        });
-  }
-
-  /** Add DnsName to Relay object. The DnsName is accessed through {@value Constants#DNSNAME}.
-   * @param rAMap The map containing the relay field
-   * @param relay The Relay object to fill
-   */
-  private static void addDnsName(Map rAMap, Relay relay) {
-    Optional.ofNullable(rAMap.get(new UnicodeString(Constants.DNSNAME))).ifPresent(o -> {
-      String dnsName = ((UnicodeString) o).getString();
-      relay.setDnsName(dnsName);
-    });
-  }
-
-  /**
-   * Add IPv6 to Relay object. The IPv6 is accessed through {@value Constants#IPV6}.
-   * @param rAMap The map containing the relay field
-   * @param relay The Relay object to fill
-   */
-  private static void addIpv6(Map rAMap, Relay relay) {
-    Optional.ofNullable(rAMap.get(new UnicodeString(Constants.IPV6))).ifPresent(o -> {
-      String ipv6 = ((UnicodeString) o).getString();
-      relay.setIpv6(ipv6);
-    });
-  }
-
-  /**
-   * Add IPv4 to Relay object. The IPv4 is accessed through {@value Constants#IPV4}.
-   * @param rAMap The map containing the relay field
-   * @param relay The Relay object to fill
-   */
-  private static void addIpv4(Map rAMap, Relay relay) {
-    Optional.ofNullable(rAMap.get(new UnicodeString(Constants.IPV4))).ifPresent(o -> {
-      String ipv4 = ((UnicodeString) o).getString();
-      relay.setIpv4(ipv4);
-    });
-  }
-
-  /**
-   * Add Type to Relay object. The type is accessed through {@value Constants#TYPE}.
-   * @param rAMap The map containing the relay field
-   * @param relay The Relay object to fill
-   */
-  private static void addRelayType(Map rAMap, Relay relay) {
-    Optional.ofNullable(rAMap.get(new UnicodeString(Constants.TYPE))).ifPresent(o -> {
-      String typeR = ((UnicodeString) rAMap.get(new UnicodeString(Constants.TYPE))).getString();
-      relay.setType(typeR);
-    });
-  }
-
-  /**
-   * Add a List of PoolOwners to Pool registration params object. The pool owners are accessed through {@value Constants#POOLOWNERS}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  private static void addPoolOwners(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.POOLOWNERS)))
-        .ifPresent(o -> {
-          List<String> stringList = new ArrayList<>();
-          List<DataItem> poolOwners = ((Array) o).getDataItems();
-          poolOwners.forEach(p -> {
-            if (p != null) {
-              stringList.add(((UnicodeString) p).getString());
-            }
-          });
-          poolRegistrationParams.setPoolOwners(stringList);
-        });
-  }
-
-  /**
-   * Add Cost to Pool registration params object. The cost is accessed through {@value Constants#COST}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  private static void addCost(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.COST)))
-        .ifPresent(o -> {
-          String cost = ((UnicodeString) o).getString();
-          poolRegistrationParams.setCost(cost);
-        });
-  }
-
-  /**
-   * Add Pledge to Pool registration params object. The pledge is accessed through {@value Constants#PLEDGE}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  private static void addPledge(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.PLEDGE)))
-        .ifPresent(o -> {
-          String pledge = ((UnicodeString) o).getString();
-          poolRegistrationParams.setPledge(pledge);
-        });
-  }
-
-  /**
-   * Add RewardAddress to Pool registration params object. The reward address is accessed through {@value Constants#REWARD_ADDRESS}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  private static void addRewardAddress(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.REWARD_ADDRESS)))
-        .ifPresent(o -> {
-          String rewardAddress = ((UnicodeString) o).getString();
-          poolRegistrationParams.setRewardAddress(rewardAddress);
-        });
-  }
-
-  /**
-   * Add VrfKeyHash to Pool registration params object. The vrf key hash is accessed through {@value Constants#VRFKEYHASH}.
-   * @param poolRegistrationParamsMap The map containing the pool registration params field
-   * @param poolRegistrationParams The PoolRegistrationParams object to fill
-   */
-  public static void addVrfKeyHash(Map poolRegistrationParamsMap,
-      PoolRegistrationParams poolRegistrationParams) {
-    Optional.ofNullable(poolRegistrationParamsMap.get(key(Constants.VRFKEYHASH)))
-        .ifPresent(o -> {
-          String vrfKeyHash = ((UnicodeString) o).getString();
-          poolRegistrationParams.setVrfKeyHash(vrfKeyHash);
-        });
-  }
-
-  /**
-   * Add PoolRegistrationCert to Operation Metadata object. The pool registration cert is accessed through {@value Constants#POOLREGISTRATIONCERT}.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addPoolRegistrationCert(Map metadataMap,
-      OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.POOLREGISTRATIONCERT)))
-        .ifPresent(o -> {
-          String poolRegistrationCert = ((UnicodeString) o).getString();
-          operationMetadata.setPoolRegistrationCert(poolRegistrationCert);
-        });
-  }
-
-  /**
-   * Add TokenBundle to Operation metadata object. The token bundle is accessed through {@value Constants#TOKENBUNDLE}.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addTokenBundle(Map metadataMap, OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.TOKENBUNDLE))).ifPresent(o -> {
-      List<DataItem> tokenBundleArray = ((Array) o).getDataItems();
-      List<TokenBundleItem> tokenBundleItems = new ArrayList<>();
-      tokenBundleArray.forEach(t -> {
-        Map tokenBundleMap = (Map) t;
-        TokenBundleItem tokenBundleItem = new TokenBundleItem();
-        // fill object
-        addPolicyIdToTokenBundleItem(tokenBundleMap, tokenBundleItem);
-        addTokensToTokenBundleItem(tokenBundleMap, tokenBundleItem);
-        // write back to tokenBundleItems
-        tokenBundleItems.add(tokenBundleItem);
-      });
-      operationMetadata.setTokenBundle(tokenBundleItems);
-    });
-  }
-
-  /**
-   * Add Tokens to TokenBundleItem object. The tokens are accessed through {@value Constants#TOKENS}.
-   * @param tokenBundleMap The map containing the token bundle field
-   * @param tokenBundleItem The TokenBundleItem object to fill
-   */
-  private static void addTokensToTokenBundleItem(Map tokenBundleMap, TokenBundleItem tokenBundleItem) {
-    List<Amount> tokenAList = new ArrayList<>();
-    Optional.ofNullable(tokenBundleMap.get(key(Constants.TOKENS))).ifPresent(o -> {
-      List<DataItem> tokensItem = ((Array) o).getDataItems();
-      tokensItem.forEach(tk -> {
-        Map tokenAmountMap = (Map) tk;
-        Amount amount1 = getAmountFromMap(tokenAmountMap);
-        tokenAList.add(amount1);
-      });
-    });
-    tokenBundleItem.setTokens(tokenAList);
-  }
-
-  /**
-   * Add PolicyId to TokenBundleItem object. The policyId is accessed
-   * @param tokenBundleMap The map containing the token bundle field
-   * @param tokenBundleItem The TokenBundleItem object to fill
-   */
-  private static void addPolicyIdToTokenBundleItem(Map tokenBundleMap, TokenBundleItem tokenBundleItem) {
-    Optional.ofNullable(tokenBundleMap.get(key(Constants.POLICYID))).ifPresent(o -> {
-      String policyId = ((UnicodeString) o).getString();
-      tokenBundleItem.setPolicyId(policyId);
-    });
-  }
-
-  /**
-   * Add Epoch to Operation metadata object. The epoch is accessed through {@value Constants#EPOCH}.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addEpoch(Map metadataMap, OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.EPOCH))).ifPresent(o -> {
-      BigInteger value = ((UnsignedInteger) metadataMap.get(
-          new UnicodeString(Constants.EPOCH))).getValue();
-      operationMetadata.setEpoch(value.intValue());
-    });
-  }
-
-  /**
-   * Add PoolKeyHash to Operation metadata object. The pool key hash is accessed through {@value Constants#POOL_KEY_HASH}.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addPoolKeyHash(Map metadataMap, OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.POOL_KEY_HASH)))
-        .ifPresent(o -> operationMetadata.setPoolKeyHash(((UnicodeString) o).getString()));
-  }
-
-  /**
-   * Add StakingCredential to Operation metadata object. The staking credential is accessed through {@value Constants#STAKING_CREDENTIAL}.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addStakingCredential(Map metadataMap, OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.STAKING_CREDENTIAL)))
-        .ifPresent(o -> {
-          Map stakingCredentialMap = (Map) o;
-          operationMetadata.setStakingCredential(getPublicKeyFromMap(stakingCredentialMap));
-        });
-  }
-
-  /**
-   * Add RefundAmount to Operation metadata object. The refund amount is accessed through {@value Constants#REFUNDAMOUNT}.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addRefundAmount(Map metadataMap, OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.REFUNDAMOUNT))).ifPresent(o -> {
-      Map refundAmountMap = (Map) o;
-      operationMetadata.setRefundAmount(getAmountFromMap(refundAmountMap));
-
-    });
-  }
-
-  /**
-   * Add DepositAmount to Operation metadata object. The deposit amount is accessed through {@value Constants#DEPOSITAMOUNT}.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addDepositAmount(Map metadataMap, OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.DEPOSITAMOUNT)))
-        .ifPresent(o -> {
-          Map depositAmountMap = (Map) o;
-          Amount amountD = getAmountFromMap(depositAmountMap);
-          operationMetadata.setDepositAmount(amountD);
-        });
-  }
-
-  /**
-   * Add WithdrawalAmount to Operation metadata object. The withdrawal amount is accessed through {@value Constants#WITHDRAWALAMOUNT}.
-   * @param metadataMap The map containing the metadata field
-   * @param operationMetadata The OperationMetadata object to fill
-   */
-  private static void addWithdrawalAmount(Map metadataMap, OperationMetadata operationMetadata) {
-    Optional.ofNullable(metadataMap.get(key(Constants.WITHDRAWALAMOUNT)))
-        .ifPresent(o -> {
-          Map withdrawalAmountMap = (Map) o;
-          Amount amountW = getAmountFromMap(withdrawalAmountMap);
-          operationMetadata.setWithdrawalAmount(amountW);
-        });
-  }
-
-  /**
-   * Returns a PublicKey object populated from the cbor MAP  if not null.
-   * @param stakingCredentialMap The map containing the staking credential field
-   * @return The populated PublicKey object
-   */
-  private static PublicKey getPublicKeyFromMap(Map stakingCredentialMap) {
-    PublicKey publicKey = new PublicKey();
-    Optional.ofNullable(stakingCredentialMap.get(new UnicodeString(Constants.HEX_BYTES)))
-        .ifPresent(o -> publicKey.setHexBytes(((UnicodeString) o).getString()));
-    Optional.ofNullable(stakingCredentialMap.get(new UnicodeString(Constants.CURVE_TYPE)))
-        .ifPresent(o -> publicKey.setCurveType(CurveType.fromValue(((UnicodeString) o).getString())));
-    return publicKey;
-  }
+    /**
+     * Returns a PublicKey object populated from the cbor MAP  if not null.
+     * @param stakingCredentialMap The map containing the staking credential field
+     * @return The populated PublicKey object
+     */
+    private static PublicKey getPublicKeyFromMap(Map stakingCredentialMap) {
+        PublicKey publicKey = new PublicKey();
+        Optional.ofNullable(stakingCredentialMap.get(new UnicodeString(Constants.HEX_BYTES)))
+                .ifPresent(o -> publicKey.setHexBytes(((UnicodeString) o).getString()));
+        Optional.ofNullable(stakingCredentialMap.get(new UnicodeString(Constants.CURVE_TYPE)))
+                .ifPresent(o -> publicKey.setCurveType(CurveType.fromValue(((UnicodeString) o).getString())));
+        return publicKey;
+    }
 
 }

--- a/api/src/main/java/org/cardanofoundation/rosetta/common/mapper/CborMapToTransactionExtraData.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/common/mapper/CborMapToTransactionExtraData.java
@@ -38,6 +38,7 @@ public class CborMapToTransactionExtraData {
       Operation operation = CborMapToOperation.cborMapToOperation(operationMap);
       operations.add(operation);
     });
+
     return new TransactionExtraData(operations, transactionMetadataHex);
   }
 

--- a/api/src/main/java/org/cardanofoundation/rosetta/common/model/cardano/transaction/TransactionData.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/common/model/cardano/transaction/TransactionData.java
@@ -2,4 +2,4 @@ package org.cardanofoundation.rosetta.common.model.cardano.transaction;
 
 import com.bloxbean.cardano.client.transaction.spec.TransactionBody;
 
-public record TransactionData (TransactionBody transactionBody, TransactionExtraData transactionExtraData) {}
+public record TransactionData(TransactionBody transactionBody, TransactionExtraData transactionExtraData) {}

--- a/api/src/test/java/org/cardanofoundation/rosetta/common/mapper/CborMapToOperationTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/common/mapper/CborMapToOperationTest.java
@@ -1,0 +1,500 @@
+package org.cardanofoundation.rosetta.common.mapper;
+
+import java.util.Collections;
+import java.util.List;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.UnicodeString;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import org.assertj.core.api.Assertions;
+import org.openapitools.client.model.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.cardanofoundation.rosetta.common.util.Constants;
+
+
+/**
+ * Unit tests for the {@link CborMapToOperation} class.
+ * These tests validate that a CBOR Map is correctly transformed into a Rosetta Operation object.
+ */
+class CborMapToOperationTest {
+
+    /**
+     * Helper method to create a UnicodeString key, mimicking the behavior of Formatters.key().
+     * This improves the readability of test data setup.
+     * @param key The string key.
+     * @return A CBOR UnicodeString.
+     */
+    private UnicodeString key(String key) {
+        return new UnicodeString(key);
+    }
+
+    @Test
+    void cborMapToOperation_shouldReturnEmptyOperation_whenMapIsEmpty() {
+        // Arrange
+        Map operationMap = new Map();
+        Operation expectedOperation = new Operation();
+
+        // Act
+        Operation actualOperation = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actualOperation)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedOperation);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapOperationIdentifier() {
+        // Arrange
+        Map operationMap = new Map();
+        Map operationIdentifierMap = new Map();
+        operationIdentifierMap.put(key(Constants.INDEX), new UnsignedInteger(1L));
+        operationIdentifierMap.put(key(Constants.NETWORK_INDEX), new UnsignedInteger(2L));
+        operationMap.put(key(Constants.OPERATION_IDENTIFIER), operationIdentifierMap);
+
+        Operation expected = new Operation();
+        expected.setOperationIdentifier(new OperationIdentifier(1L, 2L));
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapRelatedOperations() {
+        // Arrange
+        Map operationMap = new Map();
+        Array relatedOperationsArray = new Array();
+        Map relatedOp1Map = new Map();
+        relatedOp1Map.put(key(Constants.INDEX), new UnsignedInteger(10L));
+        Map relatedOp2Map = new Map();
+        relatedOp2Map.put(key(Constants.INDEX), new UnsignedInteger(11L));
+        relatedOp2Map.put(key(Constants.NETWORK_INDEX), new UnsignedInteger(5L));
+        relatedOperationsArray.add(relatedOp1Map);
+        relatedOperationsArray.add(relatedOp2Map);
+        operationMap.put(key(Constants.RELATED_OPERATION), relatedOperationsArray);
+
+        Operation expected = new Operation();
+        expected.setRelatedOperations(List.of(
+                new OperationIdentifier(10L, null),
+                new OperationIdentifier(11L, 5L)
+        ));
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapTypeAndStatus() {
+        // Arrange
+        Map operationMap = new Map();
+        operationMap.put(key(Constants.TYPE), new UnicodeString("input"));
+        operationMap.put(key(Constants.STATUS), new UnicodeString("success"));
+
+        Operation expected = new Operation();
+        expected.setType("input");
+        expected.setStatus("success");
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+//    @Test
+//    void cborMapToOperation_shouldMapFullAccountIdentifier() {
+//        // Arrange
+//        Map operationMap = new Map();
+//        Map accountMap = new Map();
+//        accountMap.put(key(Constants.ADDRESS), new UnicodeString("addr1..."));
+//
+//        Map subAccountMap = new Map();
+//        subAccountMap.put(key(Constants.ADDRESS), new UnicodeString("stake1..."));
+//        accountMap.put(key(Constants.SUB_ACCOUNT), subAccountMap);
+//
+//        Map accountMetadataMap = new Map();
+//        accountMetadataMap.put(key(Constants.CHAIN_CODE), new UnicodeString("chain_code_hex"));
+//        accountMap.put(key(Constants.METADATA), accountMetadataMap);
+//        operationMap.put(key(Constants.ACCOUNT), accountMap);
+//
+//        Operation expected = new Operation();
+//        AccountIdentifierMetadata accountIdentifierMetadata = new AccountIdentifierMetadata().chainCode("chain_code_hex");
+//        SubAccountIdentifier subAccount = new SubAccountIdentifier("stake1...", accountIdentifierMetadata);
+//        AccountIdentifier account = new AccountIdentifier("addr1...", subAccount, accountIdentifierMetadata);
+//        account.setSubAccount(subAccount);
+//        account.setMetadata(accountIdentifierMetadata);
+//        expected.setAccount(account);
+//
+//        // Act
+//        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+//
+//        // Assert
+//        Assertions.assertThat(actual)
+//                .usingRecursiveComparison()
+//                .isEqualTo(expected);
+//    }
+
+    @Test
+    void cborMapToOperation_shouldMapAmountWithCurrencyAndPolicyId() {
+        // Arrange
+        Map operationMap = new Map();
+        Map amountMap = new Map();
+        amountMap.put(key(Constants.VALUE), new UnicodeString("1000000"));
+
+        Map currencyMap = new Map();
+        currencyMap.put(key(Constants.SYMBOL), new UnicodeString("tADA"));
+        currencyMap.put(key(Constants.DECIMALS), new UnsignedInteger(6));
+
+        Map currencyMetadataMap = new Map();
+        currencyMetadataMap.put(key(Constants.POLICYID), new UnicodeString("policy123"));
+        currencyMap.put(key(Constants.METADATA), currencyMetadataMap);
+
+        amountMap.put(key(Constants.CURRENCY), currencyMap);
+        operationMap.put(key(Constants.AMOUNT), amountMap);
+
+        Operation expected = new Operation();
+        Currency currency = new Currency("tADA", 6, null);
+        currency.setMetadata(new CurrencyMetadata().policyId("policy123"));
+        Amount amount = new Amount("1000000", currency, null);
+        expected.setAmount(amount);
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapCoinChange() {
+        // Arrange
+        Map operationMap = new Map();
+        Map coinChangeMap = new Map();
+        coinChangeMap.put(key(Constants.COIN_ACTION), new UnicodeString(CoinAction.SPENT.getValue()));
+
+        Map coinIdentifierMap = new Map();
+        coinIdentifierMap.put(key(Constants.IDENTIFIER), new UnicodeString("tx1_hash:0"));
+        coinChangeMap.put(key(Constants.COIN_IDENTIFIER), coinIdentifierMap);
+
+        operationMap.put(key(Constants.COIN_CHANGE), coinChangeMap);
+
+        Operation expected = new Operation();
+        CoinChange coinChange = new CoinChange();
+        coinChange.setCoinAction(CoinAction.SPENT);
+        coinChange.setCoinIdentifier(new CoinIdentifier("tx1_hash:0"));
+        expected.setCoinChange(coinChange);
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapMetadataWithSimpleFields() {
+        // Arrange
+        Map operationMap = new Map();
+        Map metadataMap = new Map();
+        metadataMap.put(key(Constants.EPOCH), new UnsignedInteger(100));
+        metadataMap.put(key(Constants.POOL_KEY_HASH), new UnicodeString("pool_hash_123"));
+        metadataMap.put(key(Constants.POOLREGISTRATIONCERT), new UnicodeString("cert_cbor_hex"));
+        operationMap.put(key(Constants.METADATA), metadataMap);
+
+        Operation expected = new Operation();
+        OperationMetadata metadata = new OperationMetadata();
+        metadata.setEpoch(100);
+        metadata.setPoolKeyHash("pool_hash_123");
+        metadata.setPoolRegistrationCert("cert_cbor_hex");
+        expected.setMetadata(metadata);
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapMetadataWithAmountFields() {
+        // Arrange
+        Map operationMap = new Map();
+        Map metadataMap = new Map();
+        Currency ada = new Currency("ADA", 6, null);
+
+        // Withdrawal Amount
+        Map withdrawalAmountMap = new Map();
+        withdrawalAmountMap.put(key(Constants.VALUE), new UnicodeString("100"));
+        withdrawalAmountMap.put(key(Constants.CURRENCY), fromCurrency(ada));
+        metadataMap.put(key(Constants.WITHDRAWALAMOUNT), withdrawalAmountMap);
+
+        // Deposit Amount
+        Map depositAmountMap = new Map();
+        depositAmountMap.put(key(Constants.VALUE), new UnicodeString("200"));
+        depositAmountMap.put(key(Constants.CURRENCY), fromCurrency(ada));
+        metadataMap.put(key(Constants.DEPOSITAMOUNT), depositAmountMap);
+
+        // Refund Amount
+        Map refundAmountMap = new Map();
+        refundAmountMap.put(key(Constants.VALUE), new UnicodeString("50"));
+        refundAmountMap.put(key(Constants.CURRENCY), fromCurrency(ada));
+        metadataMap.put(key(Constants.REFUNDAMOUNT), refundAmountMap);
+
+        operationMap.put(key(Constants.METADATA), metadataMap);
+
+
+        Operation expected = new Operation();
+        OperationMetadata metadata = new OperationMetadata();
+        metadata.setWithdrawalAmount(new Amount("100", ada, null));
+        metadata.setDepositAmount(new Amount("200", ada, null));
+        metadata.setRefundAmount(new Amount("50", ada, null));
+        expected.setMetadata(metadata);
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapStakingCredential() {
+        // Arrange
+        Map operationMap = new Map();
+        Map metadataMap = new Map();
+        Map stakingCredentialMap = new Map();
+        stakingCredentialMap.put(key(Constants.HEX_BYTES), new UnicodeString("hex_bytes_123"));
+        stakingCredentialMap.put(key(Constants.CURVE_TYPE), new UnicodeString(CurveType.EDWARDS25519.getValue()));
+        metadataMap.put(key(Constants.STAKING_CREDENTIAL), stakingCredentialMap);
+        operationMap.put(key(Constants.METADATA), metadataMap);
+
+        Operation expected = new Operation();
+        OperationMetadata metadata = new OperationMetadata();
+        PublicKey publicKey = new PublicKey("hex_bytes_123", CurveType.EDWARDS25519);
+        metadata.setStakingCredential(publicKey);
+        expected.setMetadata(metadata);
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapTokenBundle() {
+        // Arrange
+        Map operationMap = new Map();
+        Map metadataMap = new Map();
+        Array tokenBundleArray = new Array();
+
+        // First Token Bundle Item
+        Map item1Map = new Map();
+        item1Map.put(key(Constants.POLICYID), new UnicodeString("policy1"));
+        Array tokens1Array = new Array();
+        Map amount1Wrapper = new Map();
+        amount1Wrapper.put(key(Constants.AMOUNT), fromAmount(new Amount("10", new Currency("tokenA", 0, null), null)));
+        tokens1Array.add(amount1Wrapper);
+        item1Map.put(key(Constants.TOKENS), tokens1Array);
+        tokenBundleArray.add(item1Map);
+
+        // Second Token Bundle Item
+        Map item2Map = new Map();
+        item2Map.put(key(Constants.POLICYID), new UnicodeString("policy2"));
+        Array tokens2Array = new Array();
+        Map amount2Wrapper = new Map();
+        amount2Wrapper.put(key(Constants.AMOUNT), fromAmount(new Amount("20", new Currency("tokenB", 0, null), null)));
+        Map amount3Wrapper = new Map();
+        amount3Wrapper.put(key(Constants.AMOUNT), fromAmount(new Amount("30", new Currency("tokenC", 0, null), null)));
+        tokens2Array.add(amount2Wrapper);
+        tokens2Array.add(amount3Wrapper);
+        item2Map.put(key(Constants.TOKENS), tokens2Array);
+        tokenBundleArray.add(item2Map);
+
+        metadataMap.put(key(Constants.TOKENBUNDLE), tokenBundleArray);
+        operationMap.put(key(Constants.METADATA), metadataMap);
+
+        Operation expected = new Operation();
+        OperationMetadata metadata = new OperationMetadata();
+        TokenBundleItem item1 = new TokenBundleItem();
+        item1.setPolicyId("policy1");
+        item1.setTokens(Collections.singletonList(new Amount("10", new Currency("tokenA", 0, null), null)));
+
+        TokenBundleItem item2 = new TokenBundleItem();
+        item2.setPolicyId("policy2");
+        item2.setTokens(List.of(
+                new Amount("20", new Currency("tokenB", 0, null), null),
+                new Amount("30", new Currency("tokenC", 0, null), null)
+        ));
+        metadata.setTokenBundle(List.of(item1, item2));
+        expected.setMetadata(metadata);
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapPoolRegistrationParams() {
+        // Arrange
+        Map operationMap = new Map();
+        Map metadataMap = new Map();
+        Map poolParamsMap = new Map();
+
+        poolParamsMap.put(key(Constants.VRFKEYHASH), new UnicodeString("vrf_hash"));
+        poolParamsMap.put(key(Constants.REWARD_ADDRESS), new UnicodeString("reward_addr"));
+        poolParamsMap.put(key(Constants.PLEDGE), new UnicodeString("1000000"));
+        poolParamsMap.put(key(Constants.COST), new UnicodeString("340000000"));
+
+        Array ownersArray = new Array();
+        ownersArray.add(new UnicodeString("owner1_hex"));
+        ownersArray.add(new UnicodeString("owner2_hex"));
+        poolParamsMap.put(key(Constants.POOLOWNERS), ownersArray);
+
+        Map marginMap = new Map();
+        marginMap.put(key(Constants.NUMERATOR), new UnicodeString("1"));
+        marginMap.put(key(Constants.DENOMINATOR), new UnicodeString("10"));
+        poolParamsMap.put(key(Constants.MARGIN), marginMap);
+
+        poolParamsMap.put(key(Constants.MARGIN_PERCENTAGE), new UnicodeString("10.0"));
+
+        Map poolMetadataMap = new Map();
+        poolMetadataMap.put(key(Constants.URL), new UnicodeString("http://pool.io"));
+        poolMetadataMap.put(key(Constants.HASH), new UnicodeString("pool_metadata_hash"));
+        poolParamsMap.put(key(Constants.POOLMETADATA), poolMetadataMap);
+
+        Array relaysArray = new Array();
+        Map relayMap = new Map();
+        relayMap.put(key(Constants.TYPE), new UnicodeString("single_host_addr"));
+        relayMap.put(key(Constants.IPV4), new UnicodeString("127.0.0.1"));
+        relaysArray.add(relayMap);
+        poolParamsMap.put(key(Constants.RELAYS), relaysArray);
+
+        metadataMap.put(key(Constants.POOLREGISTRATIONPARAMS), poolParamsMap);
+        operationMap.put(key(Constants.METADATA), metadataMap);
+
+        // Expected
+        Operation expected = new Operation();
+        OperationMetadata metadata = new OperationMetadata();
+        PoolRegistrationParams params = new PoolRegistrationParams();
+        params.setVrfKeyHash("vrf_hash");
+        params.setRewardAddress("reward_addr");
+        params.setPledge("1000000");
+        params.setCost("340000000");
+        params.setPoolOwners(List.of("owner1_hex", "owner2_hex"));
+        params.setMargin(new PoolMargin().numerator("1").denominator("10"));
+        params.setMarginPercentage("10.0");
+        params.setPoolMetadata(new PoolMetadata().url("http://pool.io").hash("pool_metadata_hash"));
+        Relay relay = new Relay();
+        relay.setType("single_host_addr");
+        relay.setIpv4("127.0.0.1");
+        params.setRelays(List.of(relay));
+        metadata.setPoolRegistrationParams(params);
+        expected.setMetadata(metadata);
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void cborMapToOperation_shouldMapVoteRegistrationMetadata() {
+        // Arrange
+        Map operationMap = new Map();
+        Map metadataMap = new Map();
+        Map voteRegMap = new Map();
+
+        Map stakeKeyMap = new Map();
+        stakeKeyMap.put(key(Constants.HEX_BYTES), new UnicodeString("stake_key_hex"));
+        stakeKeyMap.put(key(Constants.CURVE_TYPE), new UnicodeString(CurveType.EDWARDS25519.getValue()));
+        voteRegMap.put(key(Constants.STAKE_KEY), stakeKeyMap);
+
+        Map votingKeyMap = new Map();
+        votingKeyMap.put(key(Constants.HEX_BYTES), new UnicodeString("voting_key_hex"));
+        votingKeyMap.put(key(Constants.CURVE_TYPE), new UnicodeString(CurveType.EDWARDS25519.getValue()));
+        voteRegMap.put(key(Constants.VOTING_KEY), votingKeyMap);
+
+        voteRegMap.put(key(Constants.REWARD_ADDRESS), new UnicodeString("reward_addr_for_vote"));
+        voteRegMap.put(key(Constants.VOTING_NONCE), new UnsignedInteger(12345));
+        voteRegMap.put(key(Constants.VOTING_SIGNATURE), new UnicodeString("vote_signature_hex"));
+
+        metadataMap.put(key(Constants.VOTEREGISTRATIONMETADATA), voteRegMap);
+        operationMap.put(key(Constants.METADATA), metadataMap);
+
+        // Expected
+        Operation expected = new Operation();
+        OperationMetadata metadata = new OperationMetadata();
+        VoteRegistrationMetadata voteMetadata = new VoteRegistrationMetadata();
+        voteMetadata.setStakeKey(new PublicKey("stake_key_hex", CurveType.EDWARDS25519));
+        voteMetadata.setVotingkey(new PublicKey("voting_key_hex", CurveType.EDWARDS25519));
+        voteMetadata.setRewardAddress("reward_addr_for_vote");
+        voteMetadata.setVotingNonce(12345);
+        voteMetadata.setVotingSignature("vote_signature_hex");
+        metadata.setVoteRegistrationMetadata(voteMetadata);
+        expected.setMetadata(metadata);
+
+        // Act
+        Operation actual = CborMapToOperation.cborMapToOperation(operationMap);
+
+        // Assert
+        Assertions.assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+
+    // Helper methods to convert Rosetta models back to CBOR DataItems for test setup
+    private Map fromCurrency(Currency currency) {
+        Map currencyMap = new Map();
+        currencyMap.put(key(Constants.SYMBOL), new UnicodeString(currency.getSymbol()));
+        currencyMap.put(key(Constants.DECIMALS), new UnsignedInteger(currency.getDecimals()));
+        if (currency.getMetadata() != null && currency.getMetadata().getPolicyId() != null) {
+            Map metadataMap = new Map();
+            metadataMap.put(key(Constants.POLICYID), new UnicodeString(currency.getMetadata().getPolicyId()));
+            currencyMap.put(key(Constants.METADATA), metadataMap);
+        }
+        return currencyMap;
+    }
+
+    private Map fromAmount(Amount amount) {
+        Map amountMap = new Map();
+        amountMap.put(key(Constants.VALUE), new UnicodeString(amount.getValue()));
+        amountMap.put(key(Constants.CURRENCY), fromCurrency(amount.getCurrency()));
+
+        return amountMap;
+    }
+
+}

--- a/api/src/test/java/org/cardanofoundation/rosetta/common/mapper/OperationServiceTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/common/mapper/OperationServiceTest.java
@@ -9,14 +9,7 @@ import com.bloxbean.cardano.client.transaction.spec.TransactionBody;
 import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
 import com.bloxbean.cardano.client.transaction.spec.Withdrawal;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.openapitools.client.model.AccountIdentifier;
-import org.openapitools.client.model.Amount;
-import org.openapitools.client.model.CurveType;
-import org.openapitools.client.model.Operation;
-import org.openapitools.client.model.OperationIdentifier;
-import org.openapitools.client.model.OperationMetadata;
-import org.openapitools.client.model.PoolRegistrationParams;
-import org.openapitools.client.model.PublicKey;
+import org.openapitools.client.model.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +32,7 @@ class OperationServiceTest {
 
   @Test
   void getSignerFromOperation_poolOperationType_test() {
-    Operation operation = getOperation("addr1", "rewardAddress",
+    Operation operation = creteTestPoolRegistrationOperation("addr1", "rewardAddress",
         List.of("poolOwner1", "poolOwner2"));
 
     List<String> poolSigners = operationService.getSignerFromOperation(NetworkEnum.MAINNET.getNetwork(), operation);
@@ -51,7 +44,7 @@ class OperationServiceTest {
 
   @Test
   void getSignerFromOperation_poolOperationRetirementType_test() {
-    Operation operation = getOperation("addr1", "rewardAddress",
+    Operation operation = creteTestPoolRegistrationOperation("addr1", "rewardAddress",
         List.of("poolOwner1", "poolOwner2"));
     operation.setType(OperationType.POOL_RETIREMENT.getValue());
 
@@ -62,7 +55,7 @@ class OperationServiceTest {
 
   @Test
   void getSignerFromOperation_poolOperationTypeWithCertificate_test() {
-    Operation operation = getOperation("addr1", "", null);
+    Operation operation = creteTestPoolRegistrationOperation("addr1", "", null);
     operation.setType(OperationType.POOL_REGISTRATION_WITH_CERT.getValue());
     operation.getMetadata().setPoolRegistrationCert(
         "8a03581c1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b558208dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db01a004c4b401a002dc6c0d81e820101581de1bb40f1a647bc88c1bd6b738db8eb66357d926474ea5ffd6baa76c9fb81581c7a9a4d5a6ac7a9d8702818fa3ea533e56c4f1de16da611a730ee3f008184001820445820f5d9505820f5d9ea167fd2e0b19647f18dd1e0826f706f6f6c4d6574616461746155726c58209ac2217288d1ae0b4e15c41b58d3e05a13206fd9ab81cb15943e4174bf30c90b");
@@ -78,7 +71,7 @@ class OperationServiceTest {
   @SuppressWarnings("java:S5778")
   @Test
   void getSignerFromOperation_poolOperationTypeWithCertificateNullable_test() {
-    Operation operation = getOperation("addr1", null, null);
+    Operation operation = creteTestPoolRegistrationOperation("addr1", null, null);
     operation.setType(OperationType.POOL_REGISTRATION_WITH_CERT.getValue());
     operation.getMetadata().setPoolRegistrationCert(null);
 
@@ -102,7 +95,7 @@ class OperationServiceTest {
 
   @Test
   void getSignerFromOperation_poolOperationTypeNullable_test() {
-    Operation operation = getOperation(null, "rewardAddress",
+    Operation operation = creteTestPoolRegistrationOperation(null, "rewardAddress",
         List.of("poolOwner1", "poolOwner2"));
 
     List<String> poolSigners = operationService.getSignerFromOperation(NetworkEnum.MAINNET.getNetwork(), operation);
@@ -175,7 +168,7 @@ class OperationServiceTest {
   @Test
   void getOperationsFromTransactionData()
       throws CborException, CborDeserializationException, CborSerializationException {
-    TransactionData transactionData = getTransactionData();
+    TransactionData transactionData = getPoolTransactionData1();
     transactionData.transactionBody().setInputs(List.of(new TransactionInput()));
     transactionData.transactionBody().setWithdrawals(List.of(new Withdrawal()));
     Operation withdrawalOperation = transactionData.transactionExtraData().operations().getFirst();
@@ -201,8 +194,8 @@ class OperationServiceTest {
         .isEqualTo("1B400D60AAF34EAF6DCBAB9BBA46001A23497886CF11066F7846933D30E5AD3F");
   }
 
-  private static Operation getOperation(String accountAddress, String rewardAddress,
-      List<String> poolOwners) {
+  private static Operation creteTestPoolRegistrationOperation(String accountAddress, String rewardAddress,
+                                                              List<String> poolOwners) {
     return Operation.builder()
         .type(OperationType.POOL_REGISTRATION.getValue())
         .account(AccountIdentifier.builder()
@@ -217,13 +210,15 @@ class OperationServiceTest {
         .build();
   }
 
-  private static TransactionData getTransactionData() {
+  private static TransactionData getPoolTransactionData1() {
+    Operation operation1 = creteTestPoolRegistrationOperation("addr1", "rewardAddress", List.of("poolOwner1", "poolOwner2"));
+    Operation operation2 = creteTestPoolRegistrationOperation("addr2", "rewardAddress", List.of("poolOwner3", "poolOwner4"));
+    TransactionExtraData transactionExtraData = new TransactionExtraData(List.of(operation1, operation2), "81a100a0");
+
     return new TransactionData(
         TransactionBody.builder().build(),
-        new TransactionExtraData(
-            List.of(getOperation("addr1", "rewardAddress", List.of("poolOwner1", "poolOwner2")),
-                getOperation("addr2", "rewardAddress", List.of("poolOwner3", "poolOwner4"))),
-            "81a100a0")
+            transactionExtraData
     );
   }
+
 }

--- a/api/src/test/java/org/cardanofoundation/rosetta/common/mapper/OperationToCborMapTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/common/mapper/OperationToCborMapTest.java
@@ -45,8 +45,9 @@ class OperationToCborMapTest {
         OperationMetadata operationMetadata = OperationMetadata.builder()
                 .poolRegistrationParams(poolRegistrationParams)
                 .refundAmount(new Amount("2", new Currency(Constants.ADA, 2, new CurrencyMetadata("policyId")), new Object()))
-                .tokenBundle(List.of(new TokenBundleItem("tokenBunlePolicyId", List.of(new Amount()))))
+                .tokenBundle(List.of(new TokenBundleItem("tokenBundlePolicyId", List.of(new Amount()))))
                 .build();
+
         Operation operation = Operation
                 .builder()
                 .operationIdentifier(new OperationIdentifier())
@@ -68,4 +69,5 @@ class OperationToCborMapTest {
         assertEquals(operation.getMetadata().getPoolRegistrationParams().getMargin(), opr.getMetadata().getPoolRegistrationParams().getMargin());
         assertEquals(operation.getMetadata().getPoolRegistrationParams().getPoolMetadata(), opr.getMetadata().getPoolRegistrationParams().getPoolMetadata());
     }
+
 }


### PR DESCRIPTION
On the left with bug fix, on the right without a bug fix:
![image](https://github.com/user-attachments/assets/b4bd650a-225d-48ae-af5b-0188aae3fd9f)

What bothered me why it worked for outputs and not for inputs as well and I believe it is because for outputs it goes into the fallback mode and discovers the data from the actual transaction body. Since outputs have fully enriched amounts and token data this is possible and even easy but it was not happening for inputs because for inputs we never implemented fallback to transaction body (instead of taking this from extra data).