### PR TITLE
feat: add test for reward withdrawal of 0 ADA in stake operations

### DIFF
--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -116,6 +116,7 @@ pytest --log-cli-level=INFO tests/test_stake_operations.py
 # Run specific stake tests (Scenario A: Separate Operations)
 pytest --log-cli-level=INFO tests/test_stake_operations.py::test_stake_key_registration
 pytest --log-cli-level=INFO tests/test_stake_operations.py::test_stake_delegation
+pytest --log-cli-level=INFO tests/test_stake_operations.py::test_reward_withdrawal_zero
 pytest --log-cli-level=INFO tests/test_stake_operations.py::test_scenario_A_deregistration
 
 # Run specific stake tests (Scenario B: Combined Operations + Votes)


### PR DESCRIPTION
- Introduced a new test case `test_reward_withdrawal_zero` to validate the functionality of withdrawing 0 ADA rewards after stake and vote delegation.
- Updated the README to include the new test command for running this specific scenario.
- Adjusted the order of the existing test to maintain proper execution sequence.