### PR TITLE
fix: update Dockerfile to include wget  ca-certificates and correct config path for single docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -213,7 +213,7 @@ RUN git clone --branch $PG_VERSION_TAG https://github.com/postgres/postgres.git 
 # Main
 FROM ubuntu:24.04
 
-RUN apt update && apt install -y --no-install-recommends jq bc sudo curl \
+RUN apt update && apt install -y --no-install-recommends jq bc sudo curl  wget ca-certificates \
   libreadline-dev \
   sudo \
   locales \
@@ -253,7 +253,7 @@ RUN ldconfig
 ENV LD_LIBRARY_PATH=/usr/local/lib
 ENV PATH=/usr/local/lib/:$PATH
 
-COPY ./config /networks
+COPY ./config/node/ /networks
 RUN mkdir /config
 
 # Copy jars


### PR DESCRIPTION
update docker/Dockerfile :
- Add wget and ca-certificates packages
- Correct the ./config to ./config/node
to run single docker rosetta-java container
fix: https://github.com/cardano-foundation/cardano-rosetta-java/issues/544