### PR TITLE
docs: Update call API endpoint, pool operations guide, and add unparsed blo…

### DIFF
--- a/api/src/main/resources/rosetta-specifications-1.4.15/api.yaml
+++ b/api/src/main/resources/rosetta-specifications-1.4.15/api.yaml
@@ -451,10 +451,12 @@ paths:
                 $ref: '#/components/schemas/Error'
   /call:
     post:
-      summary: Make a Network-Specific Procedure Call
+      summary: Cardano-Specific Procedure Call
       description: |
-        Call invokes an arbitrary, network-specific procedure call with network-specific parameters. The guidance for what this endpoint should or could do is purposely left vague. In Ethereum, this could be used to invoke `eth_call` to implement an entire Rosetta API interface for some smart contract that is not parsed by the implementation creator (like a DEX). This endpoint could also be used to provide access to data that does not map to any Rosetta models instead of requiring an integrator to use some network-specific SDK and call some network-specific endpoint (like surfacing staking parameters). Call is NOT a replacement for implementing Rosetta API endpoints or mapping network-specific data to Rosetta models. Rather, it enables developers to build additional Rosetta API interfaces for things they care about without introducing complexity into a base-level Rosetta implementation. Simply put, imagine that the average integrator will use layered Rosetta API implementations that each surfaces unique data.
-        
+        Starting from Rosetta-java version 1.3.0, the parameter `CONTINUE_PARSING_ON_ERROR=true|false` has been added to allow exchanges and integrators to configure yaci-core to ignore unparsed blocks and store them in a separate error table in the database.
+        This is a Cardano network-specific procedure call, using Coinbase Mesh’s generic /call endpoint. It enables exchanges and integrators to:
+        - Review blocks that could not be fully parsed.
+        - Mark blocks as “checked” if they do not affect their users or transactions.
         ## Supported Methods
         
         ### get_parse_error_blocks
@@ -564,13 +566,13 @@ components:
       properties:
         blockchain:
           type: string
-          example: bitcoin
+          example: cardano
         network:
           description: If a blockchain has a specific chain-id or network identifier, it should go in this field. It is up to the client to determine which network-specific identifier is mainnet or testnet.
           type: string
           example: mainnet
-        sub_network_identifier:
-          $ref: '#/components/schemas/SubNetworkIdentifier'
+        # sub_network_identifier:
+        #   $ref: '#/components/schemas/SubNetworkIdentifier'
     SubNetworkIdentifier:
       description: In blockchains with sharded state, the SubNetworkIdentifier is required to query some object on a specific shard. This identifier is optional for all non-sharded blockchains.
       type: object

--- a/docs/docs/advanced-configuration/unparsed_blocks.md
+++ b/docs/docs/advanced-configuration/unparsed_blocks.md
@@ -69,6 +69,7 @@ curl --location 'http://localhost:8082/call' \
     "idempotent": false
 }
 ```
+📚 For detailed information, please see the **[API page](/cardano-rosetta-java/api#tag/call/post/call)**.
 
 ### 2.2 Mark blocks as “checked” if they do not affect users or transactions
 After reviewing a block, you can mark it as reviewed with a comment and status.
@@ -115,4 +116,25 @@ curl --location 'http://localhost:8082/call' \
     "idempotent": true
 }
 ```
+📚 For detailed information, please see the **[API page](/cardano-rosetta-java/api#tag/call/post/call)**.
+
+### 2.3 What to do when unparsed blocks are detected
+When **yaci-core** encounters unparsed blocks, and you want to attempt parsing them again after resolving the issue (e.g. upgrading parser logic), follow these steps:
+
+1. **Upgrade `yaci-core`** to the latest version that supports parsing the problematic block(s).  
+2. **Remove the data volume** used by the indexer.  
+ ```bash
+  docker compose --env-file .env.docker-compose \
+  --env-file .env.docker-compose-profile-mid-level \
+  -f docker-compose.yaml stop yaci-indexer
+
+  docker volume rm cardano-rosetta-java_data
+   
+ ```
+3. **Restart the indexer service** using Docker Compose:
+ ```bash
+  docker compose --env-file .env.docker-compose \
+  --env-file .env.docker-compose-profile-mid-level \
+  -f docker-compose.yaml start yaci-indexer
+ ```
 

--- a/docs/docs/advanced-configuration/unparsed_blocks.md
+++ b/docs/docs/advanced-configuration/unparsed_blocks.md
@@ -1,0 +1,118 @@
+# Handling Unparsed Blocks
+
+## 1. Overview
+
+In some cases, **yaci-core** may not be able to parse certain Cardano blocks due to unexpected or malformed data. To address this, **yaci-store** has introduced a feature that allows these **unparsed blocks to be ignored** and **stored in a separate error table** in the database, instead of halting the indexing process.
+
+With this graceful error handling in place, it's now possible to surface these parse-error blocks to exchanges and integrators so they can:
+
+- Detect if any of their transactions are present in an errored block.
+- Review and “mark checked” blocks if they do not impact their users or operations.
+
+This capability is exposed as **Cardano network-specific procedure calls**, using **Coinbase Mesh’s generic `/call` endpoint**, which supports **dynamic method routing**. This allows clients to query and update the state of errored blocks in a flexible and standardized way.
+
+Starting from **Rosetta-java version 1.3.0**, the parameter `CONTINUE_PARSING_ON_ERROR=true|false` has been introduced:
+
+- When it is set to `true`, yaci-core will skip unparsed blocks and add them to the error table.
+- When it is set to `false`, yaci-core will stop indexing when it encounters an unparsed block.
+
+---
+
+## 2. How to Use
+
+You can interact with the parse-error block system through the `/call` endpoint. Below are the available operations.
+
+### 2.1 Review blocks that could not be fully parsed
+
+Use this call to get the list of blocks that failed to parse.
+
+#### Request
+
+```bash
+curl --location 'http://localhost:8082/call' \
+--header 'Content-Type: application/json' \
+--data '{
+  "network_identifier": {
+    "blockchain": "cardano",
+    "network": "preprod"
+  },
+  "method": "get_parse_error_blocks",
+  "parameters": {
+    "status": "UNREVIEWED"
+  }
+}'
+```
+:::note
+- Pagination is not required, as the number of errored blocks is expected to be low.
+:::
+#### Response
+```json
+{
+    "result": {
+        "parse_error_blocks": [
+            {
+                "error_id": 1,
+                "block_number": 3686994,
+                "status": "UNREVIEWED",
+                "lastUpdated": "2025-07-18T16:18:00.266457",
+                "note": "Please review all transactions within a block, https://explorer.cardano.org/block/3686994"
+            },
+            {
+                "error_id": 2,
+                "block_number": 3686995,
+                "status": "UNREVIEWED",
+                "lastUpdated": "2025-07-18T16:18:00.266457",
+                "note": "Please review all transactions within a block, https://explorer.cardano.org/block/3686995"
+            } 
+        ]
+    },
+    "idempotent": false
+}
+```
+
+### 2.2 Mark blocks as “checked” if they do not affect users or transactions
+After reviewing a block, you can mark it as reviewed with a comment and status.
+#### Request
+
+```bash
+curl --location 'http://localhost:8082/call' \
+--header 'Content-Type: application/json' \
+--data '{
+  "network_identifier": {
+    "blockchain": "cardano",
+    "network": "preprod"
+  },
+  "method": "mark_parse_error_block_checked",
+  "parameters": {
+    "block_number": 3686994,
+    "status": "REVIEWED_DOES_NOT_AFFECT_US",
+    "comment": "no impact to operation",
+    "checked_by": "Admin"
+  }
+}
+```
+:::note
+- `block_number` specifies which block to update.
+- `status` reflects the outcome of your review, e.g., REVIEWED_DOES_NOT_AFFECT_US.
+- Use `comment` and `checked_by` fields to provide audit context.
+:::
+
+#### Response
+```json
+{
+    "result": {
+        "parse_error_blocks_response": [
+            {
+                "error_id": 1,
+                "block_number": 3686994,
+                "status": "REVIEWED_DOES_NOT_AFFECT_US",
+                "comment": "no impact to operation",
+                "checked_by": "Admin",
+                "lastUpdated": "2025-07-28T04:25:57.632987219"
+            }
+        ]
+    },
+    "idempotent": true
+}
+```
+

--- a/docs/docs/install-and-deploy/env-vars.md
+++ b/docs/docs/install-and-deploy/env-vars.md
@@ -83,7 +83,7 @@ Within root folder of the project there are example `.env` files, which can be c
 | `DB_POSTGRES_BGWRITER_DELAY`                  | Delay between background writer cycles           | 200ms (mid-level profile)             | added in release 1.2.6   |
 | `BLOCK_TRANSACTION_API_TIMEOUT_SECS`          | Timeout for fetching blocks in seconds           | 5                                     | added in release 1.2.11  |
 | `CONTINUE_PARSING_ON_ERROR`                   | Continue processing failed to parse blocks       | true                                  | added in release 1.3.0   |
-| `SYNC`                                        | DB, indexer containers only start once the cardano node is at the tip       | true: online mode, false: offline mode| added in release 1.3.0   |
+| `SYNC`                                        | DB, indexer containers only start once the cardano node is at the tip       | true: online mode, false: offline mode| added in release 1.2.0   |
 
 ## Deprecated Environment Variables (Previous Versions)
 

--- a/docs/docs/install-and-deploy/env-vars.md
+++ b/docs/docs/install-and-deploy/env-vars.md
@@ -83,6 +83,7 @@ Within root folder of the project there are example `.env` files, which can be c
 | `DB_POSTGRES_BGWRITER_DELAY`                  | Delay between background writer cycles           | 200ms (mid-level profile)             | added in release 1.2.6   |
 | `BLOCK_TRANSACTION_API_TIMEOUT_SECS`          | Timeout for fetching blocks in seconds           | 5                                     | added in release 1.2.11  |
 | `CONTINUE_PARSING_ON_ERROR`                   | Continue processing failed to parse blocks       | true                                  | added in release 1.3.0   |
+| `SYNC`                                        | DB, indexer containers only start once the cardano node is at the tip       | true: online mode, false: offline mode| added in release 1.3.0   |
 
 ## Deprecated Environment Variables (Previous Versions)
 

--- a/docs/docs/user-guides/pool-operations.md
+++ b/docs/docs/user-guides/pool-operations.md
@@ -47,7 +47,6 @@ A pool registration operation requires `poolRegistrationParams` as metadata. The
         "index": 3
       },
       "type": "poolRegistration",
-      "status": "success",
       "account": {
         "address": "1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5"
       },
@@ -97,7 +96,6 @@ For pool registration using a pre-created certificate, you need to include the c
     "index": 3
   },
   "type": "poolRegistrationWithCert",
-  "status": "success",
   "account": {
     "address": "1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5"
   },
@@ -118,7 +116,6 @@ To retire a stake pool, you need to specify the epoch in which the pool should b
     "index": 1
   },
   "type": "poolRetirement",
-  "status": "success",
   "account": {
     "address": "153806dbcd134ddee69a8c5204e38ac80448f62342f8c23cfe4b7edf"
   },
@@ -139,7 +136,6 @@ To vote for governance action, you need to specify value for `governance_action_
      "index": 3
  },
  "type": "poolGovernanceVote",
- "status": "success",
  "account": {
      "address": "6c518b4861bb88b1395ceb116342cecbcfb8736282655f9a61c4c368"
  },

--- a/docs/docs/user-guides/pool-operations.md
+++ b/docs/docs/user-guides/pool-operations.md
@@ -22,12 +22,13 @@ In addition to standard transaction operations, the following operations are ava
 | `poolRegistration`         | Register a new stake pool                       |
 | `poolRegistrationWithCert` | Register a pool using a pre-created certificate |
 | `poolRetirement`           | Retire an existing stake pool                   |
+| `poolGovernanceVote`       | SPO submit governance vote                      |
 
 :::note
 For all pool operations, the cold key is needed to sign the payloads, so it will be passed as an address.
 :::
 
-## Pool Registration
+## Pool Operations
 
 <Tabs>
   <TabItem value="standard" label="Standard Registration" default>
@@ -124,6 +125,38 @@ To retire a stake pool, you need to specify the epoch in which the pool should b
   "metadata": {
     "epoch": 200
   }
+}
+```
+
+  </TabItem>
+    <TabItem value="Voting" label="Governance vote">
+
+To vote for governance action, you need to specify value for `governance_action_hash`, `pool_credential`, `vote` and `vote_rationale` is an option
+
+```json
+{
+ "operation_identifier": {
+     "index": 3
+ },
+ "type": "poolGovernanceVote",
+ "status": "success",
+ "account": {
+     "address": "6c518b4861bb88b1395ceb116342cecbcfb8736282655f9a61c4c368"
+ },
+ "metadata": {
+     "poolGovernanceVoteParams": {
+         "governance_action_hash": "40c2a42fe324759a640dcfddbc69ef2e3b7fe5a998af8d6660359772bf44c9dc00",
+         "pool_credential": {
+             "hex_bytes": "60afbe982faaee34b02ad0e75cd50d5d7a734f5daaf7b67bc8c492eb5299af2b",
+             "curve_type": "edwards25519"
+         },
+         "vote": "yes",
+         "vote_rationale": {
+            "data_hash": "c77f8427e2808cbd4c7093aa704fb0fcb48b2ab3bdd84fa7f4dec2eb7de344c9",
+            "url": "ipfs://bafybeig7hluox6xefqdgmwcntvsguxcziw2oeogg2fbvygex2aj6qcfo64"
+          }
+     }
+ }
 }
 ```
 


### PR DESCRIPTION
### Summary
This PR updates the following documentation:

- `api.yaml`: Updated /call endpoint specification
- `docs/user-guides/pool-operations.md`:  add  `poolGovernanceVote` to pool operation.
- `docs/advanced-configuration/unparsed_blocks.md`: Added new documentation for handling unparsed blocks in `yaci-core`.

### Impact
- Affects only documentation and API spec files.
- No code logic changes.