### PR TITLE
docs: Update performance document and add 1.3.1 test results

### DIFF
--- a/docs/docs/development/performance-measurements.md
+++ b/docs/docs/development/performance-measurements.md
@@ -7,6 +7,9 @@ description: Performance measurement methodologies and results
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AdvDockerCompose131_pruned  from './test-results/1.3.1/advanced_profile/docker-compose-pruned.md';
+import MidDockerCompose131 from './test-results/1.3.1/mid_profile/docker-compose.md';
+
 import MidDockerCompose129 from './test-results/1.2.9/mid_profile/docker-compose.md';
 import MidHugeAddress373kv129 from './test-results/1.2.9/mid_profile/huge-address-373k.md';
 import MidHugeAddress16Mv129 from './test-results/1.2.9/mid_profile/huge-address-1.6M.md';
@@ -53,6 +56,53 @@ Load tests are conducted using Apache Bench (ab) with a ramp-up strategy, progre
 :::tip
 To better understand the environments in which these results were obtained, please refer to our [hardware profiles documentation](../install-and-deploy/hardware-profiles).
 :::
+
+<details>
+<summary>
+### v1.3.1 (Aug 7, 2025)
+</summary>
+- [Release Notes](https://github.com/cardano-foundation/cardano-rosetta-java/releases/tag/1.3.1)
+<details>
+<summary>
+ **Mid-level Hardware Profile** 
+</summary>
+**Machine Specs:** 8 cores, 8 threads, 47GB RAM, 3.9TB NVMe, QEMU Virtual CPU v2.5+
+
+Maximum concurrency achieved for each modes:
+<details>
+
+<summary>
+#### Pruning Disabled (`REMOVE_SPENT_UTXOS=false`)
+</summary>
+<Tabs>
+  <TabItem value="mid_docker_compose131" label="Docker Compose" default>
+    <MidDockerCompose131 />
+  </TabItem>
+</Tabs>
+</details>
+</details>
+
+<details>
+<summary>
+ **Advanced-level Hardware Profile** 
+</summary>
+**Machine Specs:** 16 cores, 16 threads, 47GB RAM, 3.9TB NVMe, QEMU Virtual CPU v2.5+
+
+Maximum concurrency achieved for each modes:
+<details>
+<summary>
+#### Pruning Enabled (`REMOVE_SPENT_UTXOS=true`)
+</summary>
+<Tabs>
+  <TabItem value="adv_docker_compose131_pruned" label="Docker Compose" default>
+    <AdvDockerCompose131_pruned />
+  </TabItem>
+</Tabs>
+</details>
+</details>
+</details>
+
+
 
 <details>
 <summary>

--- a/docs/docs/development/test-results/1.3.1/advanced_profile/docker-compose-pruned.md
+++ b/docs/docs/development/test-results/1.3.1/advanced_profile/docker-compose-pruned.md
@@ -1,0 +1,14 @@
+Data is taken from the test with spent UTXOs are retained for 30 days by setting `REMOVE_SPENT_UTXOS_LAST_BLOCKS_GRACE_COUNT=129600`
+
+| ID | Endpoint                | Max Concurrency | p95 (ms) | p99 (ms) | Non-2xx | Error Rate (%) | Reqs/sec   |
+|----|-------------------------|------------------|----------|----------|----------|------------------|-----------|
+| 1  | /network/status         | 1000             | 293ms    | 368ms    | 0        | 0.00%            | 7965.05   |
+| 2  | /account/balance        | 675              | 503ms    | 841ms    | 0        | 0.00%            | 2520.33   |
+| 3  | /account/coins          | 575              | 410ms    | 678ms    | 0        | 0.00%            | 2761.44   |
+| 4  | /block                  | 425              | 765ms    | 929ms    | 0        | 0.00%            | 861.76    |
+| 5  | /block/transaction      | 375              | 758ms    | 935ms    | 0        | 0.00%            | 772.02    |
+| 6  | /search/transactions    | 550              | 384ms    | 468ms    | 0        | 0.00%            | 2748.95   |
+| 7  | /search/transactions    | 20               | 899ms    | 953ms    | 0        | 0.00%            | 27.41     |
+| 8  | /construction/metadata  | 1000             | 501ms    | 705ms    | 0        | 0.00%            | 10317.23  |
+
+> The first `/search/transactions` result was executed using `tx_hash`, while the second one was executed using `address`.

--- a/docs/docs/development/test-results/1.3.1/mid_profile/docker-compose.md
+++ b/docs/docs/development/test-results/1.3.1/mid_profile/docker-compose.md
@@ -1,0 +1,13 @@
+
+| ID | Endpoint                | Max Concurrency | p95 (ms) | p99 (ms) | Non-2xx | Error Rate (%) | Reqs/sec   |
+|----|-------------------------|------------------|----------|----------|----------|------------------|-----------|
+| 1  | /network/status         | 700              | 227ms    | 308ms    | 0        | 0.00%            | 6699.38   |
+| 2  | /account/balance        | 200              | 817ms    | 947ms    | 0        | 0.00%            | 342.02    |
+| 3  | /account/coins          | 225              | 864ms    | 982ms    | 0        | 0.00%            | 360.73    |
+| 4  | /block                  | 175              | 693ms    | 966ms    | 150      | 0.67%            | 375.43    |
+| 5  | /block/transaction      | 175              | 566ms    | 716ms    | 149      | 0.55%            | 452.90    |
+| 6  | /search/transactions    | 175              | 162ms    | 211ms    | 150      | 0.30%            | 1621.06   |
+| 7  | /search/transactions    | 0                | 0ms      | 0ms      | 0        | 0.00%            | 0.00      |
+| 8  | /construction/metadata  | 700              | 369ms    | 703ms    | 0        | 0.00%            | 8418.52   |
+
+> The first `/search/transactions` result was executed using `tx_hash`, while the second one was executed using `address`.

--- a/docs/docs/development/test-results/1.3.1/mid_profile/docker-compose.md
+++ b/docs/docs/development/test-results/1.3.1/mid_profile/docker-compose.md
@@ -1,3 +1,6 @@
+The performance metrics in this table were measured against an SLA of 1000 ms, except for **ID = 7** (/search/transactions), which was measured against an **SLA of 10000 ms**.
+
+The first `/search/transactions` result was executed using `tx_hash` with SLA=1000ms, while the second one was executed using `address` with **(SLA of 10000ms)**,.
 
 | ID | Endpoint                | Max Concurrency | p95 (ms) | p99 (ms) | Non-2xx | Error Rate (%) | Reqs/sec   |
 |----|-------------------------|------------------|----------|----------|----------|------------------|-----------|
@@ -7,7 +10,5 @@
 | 4  | /block                  | 175              | 693ms    | 966ms    | 150      | 0.67%            | 375.43    |
 | 5  | /block/transaction      | 175              | 566ms    | 716ms    | 149      | 0.55%            | 452.90    |
 | 6  | /search/transactions    | 175              | 162ms    | 211ms    | 150      | 0.30%            | 1621.06   |
-| 7  | /search/transactions    | 0                | 0ms      | 0ms      | 0        | 0.00%            | 0.00      |
+| 7  | /search/transactions    | 125              | 8228ms   | 9562ms   | 0        | 0.00%            | 19.25     |
 | 8  | /construction/metadata  | 700              | 369ms    | 703ms    | 0        | 0.00%            | 8418.52   |
-
-> The first `/search/transactions` result was executed using `tx_hash`, while the second one was executed using `address`.


### PR DESCRIPTION
### Summary
This PR updates the following documentation:

- `performance-measurements.md`: add v1.3.1  performance document 
- Add `./test-results/1.3.1/` folder and test result files

### Impact
- Affects only documentation
