### PR TITLE
fix: Fix the incorrect API URL in the documentation.

### DIFF
--- a/docs/docs/core-concepts/cardano-addons.md
+++ b/docs/docs/core-concepts/cardano-addons.md
@@ -98,7 +98,7 @@ For transaction fields for the `size` and `scriptSize` are added to Transaction 
 }
 ```
 
-### `/block/transactions`
+### `/block/transaction`
 
 When the block requested contains transactions with multi assets operations, the token bundles associated to each operation will be returned as metadata. 
 

--- a/docs/docs/user-guides/multi-assets.md
+++ b/docs/docs/user-guides/multi-assets.md
@@ -38,7 +38,7 @@ When spending native tokens in **input operations**, the token values in the `to
 :::info Minting and Burning Observations
 **Rosetta API only supports transferring existing native tokens through the Construction API.** Minting and burning operations cannot be initiated through Rosetta.
 
-However, when querying blockchain data through endpoints like `/block/transactions`, you may observe minting and burning transactions with these patterns:
+However, when querying blockchain data through endpoints like `/block/transaction`, you may observe minting and burning transactions with these patterns:
 - **Minting**: Token appears only in outputs with positive value (no corresponding input)
 - **Burning**: Token appears only in inputs with negative value (no corresponding output)  
 - **Partial burning**: Token in inputs (negative) and outputs (positive remainder). The burned amount is the difference


### PR DESCRIPTION
After testing, I found that the URI in the documentation does not match the URI after the node deployment. After verification, the URI in the documentation is incorrect.