### PR TITLE
docs: align v2.1.0 guides (drep, staking, pool ops) and env vars

### DIFF
--- a/docs/docs/install-and-deploy/env-vars.md
+++ b/docs/docs/install-and-deploy/env-vars.md
@@ -40,17 +40,17 @@ Hardware profile files should be used **in combination** with a base `.env.docke
 | `NETWORK`                                     | Network                                                               | mainnet                                | added in release 1.0.0  |
 | `MITHRIL_SYNC`                                | Sync from Mithril snapshot                                            | true                                   | added in release 1.0.0  |
 | `PROTOCOL_MAGIC`                              | Cardano protocol magic                                                | 764824073                              | added in release 1.0.0  |
-| `PG_VERSION_TAG`                              | Postgres version tag for building from source                         | REL_14_11                              | added in release 1.2.9  |
+| `PG_VERSION_TAG`                              | Postgres version tag for building from source                         | REL_18_0                               | added in release 1.2.9  |
 | `DB_NAME`                                     | Postgres database                                                     | rosetta-java                           | added in release 1.0.0  |
 | `DB_USER`                                     | Postgres admin user                                                   | rosetta_db_admin                       | added in release 1.0.0  |
 | `DB_SECRET`                                   | Postgres admin secret                                                 | weakpwd#123_d                          | added in release 1.0.0  |
 | `DB_HOST`                                     | Postgres host                                                         | db                                     | added in release 1.0.0  |
 | `DB_PORT`                                     | Postgres port                                                         | 5432                                   | added in release 1.0.0  |
-| `DB_SCHEMA`                                   | Database schema                                                       | mainnet                                | added in release 1.0.0  |
-| `DB_PATH`                                     | Database path                                                         | data                                   | added in release 1.0.0  |
+| `DB_SCHEMA`                                   | Database schema                                                       | public                                 | added in release 1.0.0  |
+| `DB_PATH`                                     | Database path                                                         | /opt/cardano-rosetta-java/mainnet/sql_data | added in release 1.0.0  |
 | `CARDANO_NODE_HOST`                           | Cardano node host                                                     | cardano-node                           | added in release 1.0.0  |
 | `CARDANO_NODE_PORT`                           | Cardano node port                                                     | 3001                                   | added in release 1.0.0  |
-| `CARDANO_NODE_VERSION`                        | Cardano node version                                                  | 10.5.3                                 | added in release 1.0.0  |
+| `CARDANO_NODE_VERSION`                        | Cardano node version                                                  | 10.5.4                                 | added in release 1.0.0  |
 | `CARDANO_NODE_SUBMIT_HOST`                    | Cardano node submit API host                                          | cardano-submit-api                     | added in release 1.0.0  |
 | `NODE_SUBMIT_API_PORT`                        | Cardano node submit API port                                          | 8090                                   | added in release 1.0.0  |
 | `CARDANO_NODE_DIR`                            | Cardano node base directory                                           | /node                                  | added in release 1.0.0  |
@@ -58,7 +58,7 @@ Hardware profile files should be used **in combination** with a base `.env.docke
 | `CARDANO_NODE_DB`                             | Cardano node db path                                                  | /node/db                               | added in release 1.0.0  |
 | `CARDANO_CONFIG`                              | Cardano node config path (host side)                                  | ./config/node/mainnet                  | added in release 1.0.0  |
 | `CARDANO_CONFIG_CONTAINER_PATH`               | Cardano node config path inside container                             | /config                                | added in release 2.0.0  |
-| `MITHRIL_VERSION`                             | Mithril client version                                                | 2524.0                                 | added in release 1.2.9  |
+| `MITHRIL_VERSION`                             | Mithril client version                                                | 2543.1-hotfix                          | added in release 1.2.9  |
 | `SNAPSHOT_DIGEST`                             | Mithril snapshot digest                                               | latest                                 | added in release 1.0.0  |
 | `AGGREGATOR_ENDPOINT`                         | Mithril aggregator endpoint (uses default if not set)                 | (empty)                                | added in release 1.0.0  |
 | `GENESIS_VERIFICATION_KEY`                    | Mithril genesis verification key (uses default if not set)            | (empty)                                | added in release 1.0.0  |
@@ -110,6 +110,10 @@ Hardware profile files should be used **in combination** with a base `.env.docke
 | `TOKEN_REGISTRY_REQUEST_TIMEOUT_SECONDS`      | Token registry request timeout in seconds                             | 2                                      | added in release 1.4.0  |
 
 </div>
+
+:::note
+`DB_PATH` default above reflects the mainnet compose profile. Preprod uses `/opt/rosetta-java-preprod/sql_data`.
+:::
 
 ## Hardware Profile Variables
 

--- a/docs/docs/user-guides/pool-operations.md
+++ b/docs/docs/user-guides/pool-operations.md
@@ -11,9 +11,9 @@ import TabItem from '@theme/TabItem';
 
 ## Overview
 
-Stake pools are a central element of Cardano's Proof of Stake system. The Rosetta API implementation supports operations for registering, updating, and retiring stake pools.
+Stake pools are a core part of Cardano's Proof of Stake system. The Rosetta API supports stake pool registration, retirement, and SPO governance voting operations.
 
-## Operation Types
+## Pool Operation Types
 
 In addition to standard transaction operations, the following operations are available for stake pool management:
 
@@ -22,13 +22,17 @@ In addition to standard transaction operations, the following operations are ava
 | `poolRegistration`         | Register a new stake pool                       |
 | `poolRegistrationWithCert` | Register a pool using a pre-created certificate |
 | `poolRetirement`           | Retire an existing stake pool                   |
-| `poolGovernanceVote`       | SPO submit governance vote                      |
+| `poolGovernanceVote`       | Submit an SPO governance vote                   |
 
-:::note
-For all pool operations, the cold key is needed to sign the payloads, so it will be passed as an address.
-:::
+## Input Rules
 
-## Pool Operations
+- For all pool operations, the cold key is required for signing and is passed as the operation `account.address`.
+- `poolRegistration` requires `poolRegistrationParams` in metadata.
+- `poolRegistrationWithCert` requires `poolRegistrationCert` (hex-encoded certificate) in metadata.
+- `poolRetirement` requires `epoch` in metadata.
+- `poolGovernanceVote` requires `poolGovernanceVoteParams`; `vote_rationale` is optional.
+
+## Construction Examples
 
 <Tabs>
   <TabItem value="standard" label="Standard Registration" default>
@@ -88,7 +92,7 @@ A pool registration operation requires `poolRegistrationParams` as metadata. The
   </TabItem>
   <TabItem value="with-cert" label="Registration With Certificate">
 
-For pool registration using a pre-created certificate, you need to include the certificate as a hex string in the `poolRegistrationCert` field.
+For registration with a pre-created certificate, include the certificate hex in `poolRegistrationCert`.
 
 ```json
 {
@@ -126,9 +130,9 @@ To retire a stake pool, you need to specify the epoch in which the pool should b
 ```
 
   </TabItem>
-    <TabItem value="Voting" label="Governance vote">
+    <TabItem value="governance-vote" label="Governance Vote">
 
-To vote for governance action, you need to specify value for `governance_action_hash`, `pool_credential`, `vote` and `vote_rationale` is an option
+To submit a governance vote, provide `governance_action_hash`, `pool_credential`, and `vote`. `vote_rationale` is optional.
 
 ```json
 {
@@ -191,9 +195,9 @@ Each segment must be a hexadecimal number between 0000 and FFFF:
 Example: 2345:0425:2ca1:0000:0000:0567:5673:23b5
 ```
 
-## Data API Examples
+## Data API Representation
 
-The Rosetta Data API returns information about pool operations in `/block` and `/block/transaction` endpoints.
+Rosetta Data API responses include pool operations in `/block` and `/block/transaction`.
 
 <Tabs>
   <TabItem value="retirement-response" label="Pool Retirement Response" default>

--- a/docs/docs/user-guides/staking.md
+++ b/docs/docs/user-guides/staking.md
@@ -34,6 +34,16 @@ The order of operations is important since they are processed in a specific sequ
 3. Withdrawals
    :::
 
+## Governance Prerequisite for Reward Withdrawals
+
+:::important
+In the current governance era, withdrawing stake rewards requires the stake credential to be delegated to a DRep.
+
+For exchange flows, treat DRep delegation as a pre-check before building `withdrawal` operations.
+:::
+
+Use the [DRep Delegation guide](/docs/user-guides/drep-delegation) to build or update `dRepVoteDelegation` operations before withdrawal when needed.
+
 ## Operation Examples
 
 <Tabs>


### PR DESCRIPTION
- DRep guide: fix CIP-129 rules from #683 (`type` inferred for prefixed ids, required for raw ids), keep 3 examples, and reorganize sections.

- Staking guide: add explicit prerequisite that reward withdrawal requires active DRep delegation.

- Pool operations guide: add per-operation required metadata and fix governance vote wording/section naming.

- Env vars guide: sync documented defaults with v2.1.0 values.