### PR TITLE
docs: add performance test results for v2.0.0 and v2.1.0

### DIFF
--- a/docs/docs/development/performance-measurements.md
+++ b/docs/docs/development/performance-measurements.md
@@ -7,6 +7,9 @@ description: Performance measurement methodologies and results
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import MidDockerCompose210 from './test-results/2.1.0/mid_profile/docker-compose.md';
+import MidDockerCompose200 from './test-results/2.0.0/mid_profile/docker-compose.md';
+
 import MidDockerCompose132 from './test-results/1.3.2/mid_profile/docker-compose.md';
 
 import AdvDockerCompose131_pruned  from './test-results/1.3.1/advanced_profile/docker-compose-pruned.md';
@@ -56,6 +59,48 @@ Load tests are conducted using Apache Bench (ab) with a ramp-up strategy, progre
 :::tip
 To better understand the environments in which these results were obtained, please refer to our [hardware profiles documentation](../install-and-deploy/hardware-profiles).
 :::
+
+<details>
+<summary>
+### v2.1.0 (Feb 17, 2026)
+</summary>
+- [Release Notes](https://github.com/cardano-foundation/cardano-rosetta-java/releases/tag/2.1.0)
+
+<details>
+<summary>
+ **Mid-level Hardware Profile**
+</summary>
+**Machine Specs:** 16 cores, 16 threads, 96GB RAM, 3.9TB HDD, QEMU Virtual CPU v2.5+
+<details>
+<Tabs>
+  <TabItem value="mid_docker_compose210" label="Docker Compose" default>
+    <MidDockerCompose210 />
+  </TabItem>
+</Tabs>
+</details>
+</details>
+</details>
+
+<details>
+<summary>
+### v2.0.0 (Feb 4, 2026)
+</summary>
+- [Release Notes](https://github.com/cardano-foundation/cardano-rosetta-java/releases/tag/2.0.0)
+
+<details>
+<summary>
+ **Mid-level Hardware Profile**
+</summary>
+**Machine Specs:** 16 cores, 16 threads, 96GB RAM, 3.9TB HDD, QEMU Virtual CPU v2.5+
+<details>
+<Tabs>
+  <TabItem value="mid_docker_compose200" label="Docker Compose" default>
+    <MidDockerCompose200 />
+  </TabItem>
+</Tabs>
+</details>
+</details>
+</details>
 
 <details>
 <summary>

--- a/docs/docs/development/test-results/2.0.0/mid_profile/docker-compose.md
+++ b/docs/docs/development/test-results/2.0.0/mid_profile/docker-compose.md
@@ -1,0 +1,12 @@
+The performance metrics in this table were measured against an SLA of 1000 ms.
+
+| ID | Endpoint                              | Max Concurrency | p95 (ms) | p99 (ms) | Non-2xx | Error Rate (%) | Reqs/sec   |
+|----|---------------------------------------|------------------|----------|----------|---------|----------------|------------|
+| 1  | /network/status                       | 125              | 30       | 37       | 0       | 0.00%          | 6797.41    |
+| 2  | /account/balance                      | 225              | 791      | 996      | 0       | 0.00%          | 448.01     |
+| 3  | /account/coins                        | 225              | 734      | 961      | 0       | 0.00%          | 493.19     |
+| 4  | /block                                | 150              | 695      | 848      | 0       | 0.00%          | 345.76     |
+| 5  | /block/transaction                    | 175              | 799      | 985      | 0       | 0.00%          | 348.11     |
+| 6  | /search/transactions (by hash)        | 175              | 82       | 104      | 0       | 0.00%          | 3785.62    |
+| 7  | /search/transactions (by address)     | 20               | 725      | 781      | 0       | 0.00%          | 33.56      |
+| 8  | /construction/metadata                | 500              | 150      | 237      | 0       | 0.00%          | 13635.74   |

--- a/docs/docs/development/test-results/2.1.0/mid_profile/docker-compose.md
+++ b/docs/docs/development/test-results/2.1.0/mid_profile/docker-compose.md
@@ -1,0 +1,12 @@
+The performance metrics in this table were measured against an SLA of 1000 ms.
+
+| ID | Endpoint                              | Max Concurrency | p95 (ms) | p99 (ms) | Non-2xx | Error Rate (%) | Reqs/sec   |
+|----|---------------------------------------|------------------|----------|----------|---------|----------------|------------|
+| 1  | /network/status                       | 125              | 35       | 46       | 0       | 0.00%          | 6152.33    |
+| 2  | /account/balance                      | 200              | 761      | 964      | 0       | 0.00%          | 439.08     |
+| 3  | /account/coins                        | 175              | 683      | 880      | 0       | 0.00%          | 459.27     |
+| 4  | /block                                | 175              | 737      | 895      | 0       | 0.00%          | 385.93     |
+| 5  | /block/transaction                    | 200              | 659      | 897      | 150     | 0.56%          | 443.63     |
+| 6  | /search/transactions (by hash)        | 175              | 79       | 101      | 0       | 0.00%          | 3915.87    |
+| 7  | /search/transactions (by address)     | 28               | 833      | 923      | 0       | 0.00%          | 43.62      |
+| 8  | /construction/metadata                | 500              | 91       | 186      | 0       | 0.00%          | 16493.65   |


### PR DESCRIPTION
## Summary
- Add legacy load test results for v2.0.0 and v2.1.0 to the performance measurements docs page
- Both versions tested on mid-level hardware profile (16 cores, 16 threads, 96GB RAM)
- Results include the new split search/transactions endpoints (by hash vs by address)

## Test plan
- [x] `yarn build` passes
- [x] Verified rendered page at `/docs/development/performance-measurements`