### PR TITLE
fix: enable token registry in preprod values

### DIFF
--- a/helm/cardano-rosetta-java/values-preprod.yaml
+++ b/helm/cardano-rosetta-java/values-preprod.yaml
@@ -22,5 +22,7 @@ rosetta-api:
   env:
     removeSpentUtxos: false
     syncGraceSlotsCount: 100
-    tokenRegistryLogoFetch: true       # DC preprod: TOKEN_REGISTRY_LOGO_FETCH=true
-    tokenRegistryCacheTtlHours: 1      # DC preprod: TOKEN_REGISTRY_CACHE_TTL_HOURS=1
+    tokenRegistryEnabled: true                                    # DC preprod: TOKEN_REGISTRY_ENABLED=true
+    tokenRegistryBaseUrl: "https://preprod.tokens.cardano.org/api" # DC preprod: TOKEN_REGISTRY_BASE_URL
+    tokenRegistryLogoFetch: true                                   # DC preprod: TOKEN_REGISTRY_LOGO_FETCH=true
+    tokenRegistryCacheTtlHours: 1                                  # DC preprod: TOKEN_REGISTRY_CACHE_TTL_HOURS=1


### PR DESCRIPTION
## Summary

- `values-preprod.yaml` configured `tokenRegistryLogoFetch` and `tokenRegistryCacheTtlHours` but never set `tokenRegistryEnabled: true` or `tokenRegistryBaseUrl`
- Without these two values, token metadata enrichment is silently disabled on preprod deployments