### PR TITLE
fix: increase index-applier deadline and node startup probe threshold

### DIFF
--- a/helm/cardano-rosetta-java/charts/cardano-node/templates/statefulset.yaml
+++ b/helm/cardano-rosetta-java/charts/cardano-node/templates/statefulset.yaml
@@ -117,7 +117,7 @@ spec:
                 - /node/node.socket
             initialDelaySeconds: 60
             periodSeconds: 15
-            failureThreshold: {{ (((.Values.node).startupProbe).failureThreshold) | default 720 }}
+            failureThreshold: {{ (((.Values.node).startupProbe).failureThreshold) | default 1920 }}
             timeoutSeconds: 5
 
         - name: socat

--- a/helm/cardano-rosetta-java/templates/index-applier-job.yaml
+++ b/helm/cardano-rosetta-java/templates/index-applier-job.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: 5
-  activeDeadlineSeconds: 86400
+  activeDeadlineSeconds: 259200
   {{- if ne (default "automatic" .Values.indexApplier.mode) "hook" }}
   # Auto-cleanup after 24h so future helm upgrades can recreate the Job without conflicts.
   ttlSecondsAfterFinished: 86400


### PR DESCRIPTION
## Summary

- Index-applier Job `activeDeadlineSeconds`: 24h -> 72h
- Cardano-node startup probe `failureThreshold` default: 720 (3h) -> 1920 (8h)

The 24h deadline caused the index-applier pod to be killed by the garbage collector before sync completed. The 3h startup probe was insufficient for ImmutableDB replay on mainnet.