### PR TITLE
fix: align policyId validation in search endpoint with account endpoint

### DIFF
--- a/api/src/main/java/org/cardanofoundation/rosetta/api/block/model/repository/TxRepositoryCustomBase.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/block/model/repository/TxRepositoryCustomBase.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.cardanofoundation.rosetta.api.jooq.Tables.*;
 
@@ -33,41 +34,57 @@ public abstract class TxRepositoryCustomBase implements TxRepositoryCustom {
      * Base class for currency condition builders that handles common logic.
      */
     protected abstract static class BaseCurrencyConditionBuilder implements TxRepositoryQueryBuilder.CurrencyConditionBuilder {
-        
+
+        private static final Pattern HEX_PATTERN = Pattern.compile("^[0-9a-fA-F]*$");
+
+        /**
+         * Validates that a value contains only hexadecimal characters.
+         * Defense-in-depth: input should already be validated at the service layer,
+         * but this ensures only safe values reach query construction.
+         */
+        private static String requireHex(String value, String fieldName) {
+            String trimmed = value.trim();
+            if (!HEX_PATTERN.matcher(trimmed).matches()) {
+                throw new IllegalArgumentException(
+                        fieldName + " must contain only hex characters, got: " + trimmed);
+            }
+            return trimmed;
+        }
+
         @Override
         public final Condition buildCurrencyCondition(Currency currency) {
             String policyId = currency.getPolicyId();
             String symbol = currency.getSymbol();
 
             if (policyId != null && !policyId.trim().isEmpty()) {
-                String escapedPolicyId = policyId.trim().replace("\"", "\\\"");
+                String validatedPolicyId = requireHex(policyId, "policyId");
 
                 if (symbol != null && !symbol.trim().isEmpty() &&
                         !"lovelace".equalsIgnoreCase(symbol) && !"ada".equalsIgnoreCase(symbol)) {
-                    String escapedSymbol = symbol.trim().replace("\"", "\\\"");
-                    return buildPolicyIdAndSymbolCondition(escapedPolicyId, escapedSymbol);
+                    String validatedSymbol = requireHex(symbol, "symbol");
+                    return buildPolicyIdAndSymbolCondition(validatedPolicyId, validatedSymbol);
                 }
 
-                return buildPolicyIdOnlyCondition(escapedPolicyId);
+                return buildPolicyIdOnlyCondition(validatedPolicyId);
             }
 
             if (symbol != null && !symbol.trim().isEmpty()) {
                 if ("lovelace".equalsIgnoreCase(symbol) || "ada".equalsIgnoreCase(symbol)) {
                     return buildLovelaceCondition();
                 } else {
-                    String escapedSymbol = symbol.trim().replace("\"", "\\\"");
-                    return buildSymbolOnlyCondition(escapedSymbol);
+                    String validatedSymbol = requireHex(symbol, "symbol");
+                    return buildSymbolOnlyCondition(validatedSymbol);
                 }
             }
 
             return DSL.falseCondition();
         }
-        
+
         // Template methods for database-specific implementations
-        protected abstract Condition buildPolicyIdAndSymbolCondition(String escapedPolicyId, String escapedSymbol);
-        protected abstract Condition buildPolicyIdOnlyCondition(String escapedPolicyId);
+        protected abstract Condition buildPolicyIdAndSymbolCondition(String validatedPolicyId, String validatedSymbol);
+        protected abstract Condition buildPolicyIdOnlyCondition(String validatedPolicyId);
         protected abstract Condition buildLovelaceCondition();
-        protected abstract Condition buildSymbolOnlyCondition(String escapedSymbol);
+        protected abstract Condition buildSymbolOnlyCondition(String validatedSymbol);
     }
     
     /**

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/block/model/repository/h2/TxRepositoryH2Impl.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/block/model/repository/h2/TxRepositoryH2Impl.java
@@ -157,18 +157,18 @@ public class TxRepositoryH2Impl extends TxRepositoryCustomBase implements TxRepo
     private static class H2CurrencyConditionBuilder extends BaseCurrencyConditionBuilder {
 
         @Override
-        protected Condition buildPolicyIdAndSymbolCondition(String escapedPolicyId, String escapedSymbol) {
+        protected Condition buildPolicyIdAndSymbolCondition(String validatedPolicyId, String validatedSymbol) {
             // Search for unit field containing policyId+symbol (hex-encoded)
             // unit = policyId + symbol where symbol is hex-encoded asset name
-            String expectedUnit = escapedPolicyId + escapedSymbol;
+            String expectedUnit = validatedPolicyId + validatedSymbol;
             return DSL.condition("EXISTS (SELECT 1 FROM address_utxo au WHERE au.tx_hash = transaction.tx_hash " +
                     "AND au.amounts LIKE '%\"unit\":\"" + expectedUnit + "\"%')");
         }
 
         @Override
-        protected Condition buildPolicyIdOnlyCondition(String escapedPolicyId) {
+        protected Condition buildPolicyIdOnlyCondition(String validatedPolicyId) {
             return DSL.condition("EXISTS (SELECT 1 FROM address_utxo au WHERE au.tx_hash = transaction.tx_hash " +
-                    "AND au.amounts LIKE '%\"policy_id\":\"" + escapedPolicyId + "\"%')");
+                    "AND au.amounts LIKE '%\"policy_id\":\"" + validatedPolicyId + "\"%')");
         }
 
         @Override
@@ -178,12 +178,12 @@ public class TxRepositoryH2Impl extends TxRepositoryCustomBase implements TxRepo
         }
 
         @Override
-        protected Condition buildSymbolOnlyCondition(String escapedSymbol) {
+        protected Condition buildSymbolOnlyCondition(String validatedSymbol) {
             // Search for unit field containing the hex-encoded symbol
             // Since unit = policyId + symbol, the unit will contain the symbol substring
             // We need to exclude lovelace since it's a special case
             return DSL.condition("EXISTS (SELECT 1 FROM address_utxo au WHERE au.tx_hash = transaction.tx_hash " +
-                    "AND au.amounts LIKE '%\"unit\":\"%"  + escapedSymbol + "\"%' " +
+                    "AND au.amounts LIKE '%\"unit\":\"%"  + validatedSymbol + "\"%' " +
                     "AND au.amounts NOT LIKE '%\"unit\":\"lovelace\"%')");
         }
     }

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/block/model/repository/postgresql/TxRepositoryPostgreSQLImpl.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/block/model/repository/postgresql/TxRepositoryPostgreSQLImpl.java
@@ -195,18 +195,18 @@ public class TxRepositoryPostgreSQLImpl extends TxRepositoryCustomBase implement
     private static class PostgreSQLCurrencyConditionBuilder extends BaseCurrencyConditionBuilder {
 
         @Override
-        protected Condition buildPolicyIdAndSymbolCondition(String escapedPolicyId, String escapedSymbol) {
+        protected Condition buildPolicyIdAndSymbolCondition(String validatedPolicyId, String validatedSymbol) {
             // Search for unit field containing policyId+symbol (hex-encoded)
             // unit = policyId + symbol where symbol is hex-encoded asset name
-            String expectedUnit = escapedPolicyId + escapedSymbol;
+            String expectedUnit = validatedPolicyId + validatedSymbol;
             return DSL.condition("EXISTS (SELECT 1 FROM address_utxo au WHERE au.tx_hash = transaction.tx_hash " +
                     "AND au.amounts::jsonb @> '[{\"unit\": \"" + expectedUnit + "\"}]')");
         }
 
         @Override
-        protected Condition buildPolicyIdOnlyCondition(String escapedPolicyId) {
+        protected Condition buildPolicyIdOnlyCondition(String validatedPolicyId) {
             return DSL.condition("EXISTS (SELECT 1 FROM address_utxo au WHERE au.tx_hash = transaction.tx_hash " +
-                    "AND au.amounts::jsonb @> '[{\"policy_id\": \"" + escapedPolicyId + "\"}]')");
+                    "AND au.amounts::jsonb @> '[{\"policy_id\": \"" + validatedPolicyId + "\"}]')");
         }
 
         @Override
@@ -216,14 +216,14 @@ public class TxRepositoryPostgreSQLImpl extends TxRepositoryCustomBase implement
         }
 
         @Override
-        protected Condition buildSymbolOnlyCondition(String escapedSymbol) {
+        protected Condition buildSymbolOnlyCondition(String validatedSymbol) {
             // Search for unit field ending with the hex-encoded symbol
             // Since unit = policyId + symbol, we look for units that end with the symbol
             // Using jsonb_array_elements to iterate through amounts array and check each unit
             return DSL.condition("EXISTS (SELECT 1 FROM address_utxo au, " +
                     "jsonb_array_elements(au.amounts::jsonb) AS amt " +
                     "WHERE au.tx_hash = transaction.tx_hash " +
-                    "AND amt->>'unit' LIKE '%" + escapedSymbol + "' " +
+                    "AND amt->>'unit' LIKE '%" + validatedSymbol + "' " +
                     "AND amt->>'unit' != 'lovelace')");
         }
     }

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/search/service/SearchServiceImpl.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/search/service/SearchServiceImpl.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import static org.cardanofoundation.rosetta.common.util.HexUtils.isHexString;
 
@@ -30,6 +31,8 @@ import static org.cardanofoundation.rosetta.common.util.HexUtils.isHexString;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class SearchServiceImpl implements SearchService {
+
+    private static final Pattern POLICY_ID_VALIDATION = Pattern.compile(Constants.POLICY_ID_VALIDATION);
 
     private final BlockMapper blockMapper;
     private final LedgerSearchService ledgerSearchService;
@@ -65,10 +68,15 @@ public class SearchServiceImpl implements SearchService {
                 .map(c -> {
                     validateCurrencySymbolIsHex(c); // Validate that currency symbol is hex-encoded (for native assets)
 
+                    @Nullable String policyId = Optional.ofNullable(c.getMetadata())
+                            .map(CurrencyMetadataRequest::getPolicyId)
+                            .orElse(null);
+                    validatePolicyId(policyId);
+
                     return org.cardanofoundation.rosetta.api.search.model.Currency.builder()
                             .symbol(c.getSymbol())
                             .decimals(c.getDecimals())
-                            .policyId(Optional.ofNullable(c.getMetadata()).map(CurrencyMetadataRequest::getPolicyId).orElse(null))
+                            .policyId(policyId)
                             .build();
                 })
                 .orElse(null);
@@ -171,6 +179,12 @@ public class SearchServiceImpl implements SearchService {
         } catch (IllegalArgumentException e) {
             String details = String.format("Unknown operator: '%s'. Supported values are: 'AND', 'OR'", operatorString);
             throw ExceptionFactory.unspecifiedErrorNotRetriable(details);
+        }
+    }
+
+    private void validatePolicyId(@Nullable String policyId) {
+        if (policyId != null && !POLICY_ID_VALIDATION.matcher(policyId).matches()) {
+            throw ExceptionFactory.invalidPolicyIdError("Given policy id is " + policyId);
         }
     }
 

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/block/model/repository/BaseCurrencyConditionBuilderTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/block/model/repository/BaseCurrencyConditionBuilderTest.java
@@ -1,0 +1,255 @@
+package org.cardanofoundation.rosetta.api.block.model.repository;
+
+import org.cardanofoundation.rosetta.api.block.model.repository.util.TxRepositoryQueryBuilder;
+import org.cardanofoundation.rosetta.api.search.model.Currency;
+import org.jooq.Condition;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BaseCurrencyConditionBuilderTest {
+
+    /**
+     * Concrete test implementation of BaseCurrencyConditionBuilder
+     * that captures what values are passed to the template methods.
+     */
+    private static class TestCurrencyConditionBuilder extends TxRepositoryCustomBase.BaseCurrencyConditionBuilder {
+
+        String lastPolicyId;
+        String lastSymbol;
+        String lastCalledMethod;
+
+        @Override
+        protected Condition buildPolicyIdAndSymbolCondition(String validatedPolicyId, String validatedSymbol) {
+            lastCalledMethod = "policyIdAndSymbol";
+            lastPolicyId = validatedPolicyId;
+            lastSymbol = validatedSymbol;
+            return DSL.trueCondition();
+        }
+
+        @Override
+        protected Condition buildPolicyIdOnlyCondition(String validatedPolicyId) {
+            lastCalledMethod = "policyIdOnly";
+            lastPolicyId = validatedPolicyId;
+            return DSL.trueCondition();
+        }
+
+        @Override
+        protected Condition buildLovelaceCondition() {
+            lastCalledMethod = "lovelace";
+            return DSL.trueCondition();
+        }
+
+        @Override
+        protected Condition buildSymbolOnlyCondition(String validatedSymbol) {
+            lastCalledMethod = "symbolOnly";
+            lastSymbol = validatedSymbol;
+            return DSL.trueCondition();
+        }
+    }
+
+    @Nested
+    class PolicyIdInputValidationTests {
+
+        @Test
+        void shouldRejectPolicyId_withUnsanitizedInput() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder()
+                    .policyId("'}]') OR 1=1 --")
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> builder.buildCurrencyCondition(currency))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("policyId must contain only hex characters");
+        }
+
+        @Test
+        void shouldRejectPolicyId_withQuotes() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder()
+                    .policyId("\"malicious\"")
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> builder.buildCurrencyCondition(currency))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("policyId must contain only hex characters");
+        }
+
+        @Test
+        void shouldRejectPolicyId_withSpecialCharacters() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder()
+                    .policyId("'; DROP TABLE transaction; --")
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> builder.buildCurrencyCondition(currency))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("policyId must contain only hex characters");
+        }
+
+        @Test
+        void shouldAcceptValidHexPolicyId() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            String validPolicyId = "d97e36383ae494e72b736ace04080f2953934626376ee06cf84adeb4";
+            Currency currency = Currency.builder()
+                    .policyId(validPolicyId)
+                    .build();
+
+            // When
+            Condition result = builder.buildCurrencyCondition(currency);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(builder.lastCalledMethod).isEqualTo("policyIdOnly");
+            assertThat(builder.lastPolicyId).isEqualTo(validPolicyId);
+        }
+
+        @Test
+        void shouldAcceptValidHexPolicyIdWithSymbol() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            String validPolicyId = "d97e36383ae494e72b736ace04080f2953934626376ee06cf84adeb4";
+            String validSymbol = "000de1404469616d6f6e64";
+            Currency currency = Currency.builder()
+                    .policyId(validPolicyId)
+                    .symbol(validSymbol)
+                    .build();
+
+            // When
+            Condition result = builder.buildCurrencyCondition(currency);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(builder.lastCalledMethod).isEqualTo("policyIdAndSymbol");
+            assertThat(builder.lastPolicyId).isEqualTo(validPolicyId);
+            assertThat(builder.lastSymbol).isEqualTo(validSymbol);
+        }
+    }
+
+    @Nested
+    class SymbolInputValidationTests {
+
+        @Test
+        void shouldRejectSymbol_withUnsanitizedInput() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder()
+                    .symbol("' OR 1=1 --")
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> builder.buildCurrencyCondition(currency))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("symbol must contain only hex characters");
+        }
+
+        @Test
+        void shouldRejectSymbol_withNonHexWhenPolicyIdPresent() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder()
+                    .policyId("d97e36383ae494e72b736ace04080f2953934626376ee06cf84adeb4")
+                    .symbol("not-hex!")
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> builder.buildCurrencyCondition(currency))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("symbol must contain only hex characters");
+        }
+
+        @Test
+        void shouldAllowLovelaceSymbol_withoutHexValidation() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder()
+                    .symbol("lovelace")
+                    .build();
+
+            // When
+            Condition result = builder.buildCurrencyCondition(currency);
+
+            // Then - lovelace is a special case, not hex validated
+            assertThat(result).isNotNull();
+            assertThat(builder.lastCalledMethod).isEqualTo("lovelace");
+        }
+
+        @Test
+        void shouldAllowAdaSymbol_withoutHexValidation() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder()
+                    .symbol("ADA")
+                    .build();
+
+            // When
+            Condition result = builder.buildCurrencyCondition(currency);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(builder.lastCalledMethod).isEqualTo("lovelace");
+        }
+    }
+
+    @Nested
+    class EdgeCaseTests {
+
+        @Test
+        void shouldReturnFalseCondition_whenBothFieldsAreNull() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder().build();
+
+            // When
+            Condition result = builder.buildCurrencyCondition(currency);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(builder.lastCalledMethod).isNull(); // no template method called
+        }
+
+        @Test
+        void shouldReturnFalseCondition_whenBothFieldsAreEmpty() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            Currency currency = Currency.builder()
+                    .policyId("")
+                    .symbol("")
+                    .build();
+
+            // When
+            Condition result = builder.buildCurrencyCondition(currency);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(builder.lastCalledMethod).isNull();
+        }
+
+        @Test
+        void shouldTrimWhitespace_fromPolicyId() {
+            // Given
+            TestCurrencyConditionBuilder builder = new TestCurrencyConditionBuilder();
+            String validPolicyId = "d97e36383ae494e72b736ace04080f2953934626376ee06cf84adeb4";
+            Currency currency = Currency.builder()
+                    .policyId("  " + validPolicyId + "  ")
+                    .build();
+
+            // When
+            Condition result = builder.buildCurrencyCondition(currency);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(builder.lastPolicyId).isEqualTo(validPolicyId);
+        }
+    }
+}

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/search/service/SearchServiceImplTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/search/service/SearchServiceImplTest.java
@@ -635,6 +635,194 @@ class SearchServiceImplTest {
     }
 
     @Nested
+    class PolicyIdValidationTests {
+
+        @Test
+        void shouldRejectPolicyId_withUnsanitizedInput() {
+            // Given - unsanitized input via policyId
+            CurrencyMetadataRequest metadata = CurrencyMetadataRequest.builder()
+                    .policyId("'}]') OR 1=1 --")
+                    .build();
+            CurrencyRequest currency = CurrencyRequest.builder()
+                    .symbol("ADA")
+                    .metadata(metadata)
+                    .build();
+
+            SearchTransactionsRequest request = SearchTransactionsRequest.builder()
+                    .networkIdentifier(networkIdentifier)
+                    .currency(currency)
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> searchService.searchTransaction(request, 0L, 10L))
+                    .isInstanceOf(ApiException.class)
+                    .extracting("error.message")
+                    .isEqualTo("Invalid policy id");
+
+            verifyNoInteractions(ledgerSearchService);
+        }
+
+        @Test
+        void shouldRejectPolicyId_tooShort() {
+            // Given - policyId with fewer than 56 hex characters
+            CurrencyMetadataRequest metadata = CurrencyMetadataRequest.builder()
+                    .policyId("abcdef1234")
+                    .build();
+            CurrencyRequest currency = CurrencyRequest.builder()
+                    .symbol("ADA")
+                    .metadata(metadata)
+                    .build();
+
+            SearchTransactionsRequest request = SearchTransactionsRequest.builder()
+                    .networkIdentifier(networkIdentifier)
+                    .currency(currency)
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> searchService.searchTransaction(request, 0L, 10L))
+                    .isInstanceOf(ApiException.class)
+                    .extracting("error.message")
+                    .isEqualTo("Invalid policy id");
+
+            verifyNoInteractions(ledgerSearchService);
+        }
+
+        @Test
+        void shouldRejectPolicyId_tooLong() {
+            // Given - policyId with more than 56 hex characters
+            String tooLongPolicyId = "a".repeat(57);
+            CurrencyMetadataRequest metadata = CurrencyMetadataRequest.builder()
+                    .policyId(tooLongPolicyId)
+                    .build();
+            CurrencyRequest currency = CurrencyRequest.builder()
+                    .symbol("ADA")
+                    .metadata(metadata)
+                    .build();
+
+            SearchTransactionsRequest request = SearchTransactionsRequest.builder()
+                    .networkIdentifier(networkIdentifier)
+                    .currency(currency)
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> searchService.searchTransaction(request, 0L, 10L))
+                    .isInstanceOf(ApiException.class)
+                    .extracting("error.message")
+                    .isEqualTo("Invalid policy id");
+
+            verifyNoInteractions(ledgerSearchService);
+        }
+
+        @Test
+        void shouldRejectPolicyId_nonHexCharacters() {
+            // Given - policyId with non-hex characters
+            CurrencyMetadataRequest metadata = CurrencyMetadataRequest.builder()
+                    .policyId("thisIsNotHexAndIsExactly56CharsLongForTestingPurposesXX")
+                    .build();
+            CurrencyRequest currency = CurrencyRequest.builder()
+                    .symbol("ADA")
+                    .metadata(metadata)
+                    .build();
+
+            SearchTransactionsRequest request = SearchTransactionsRequest.builder()
+                    .networkIdentifier(networkIdentifier)
+                    .currency(currency)
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> searchService.searchTransaction(request, 0L, 10L))
+                    .isInstanceOf(ApiException.class)
+                    .extracting("error.message")
+                    .isEqualTo("Invalid policy id");
+
+            verifyNoInteractions(ledgerSearchService);
+        }
+
+        @Test
+        void shouldRejectPolicyId_withSpecialCharacters() {
+            // Given - policyId with special characters
+            CurrencyMetadataRequest metadata = CurrencyMetadataRequest.builder()
+                    .policyId("'; DROP TABLE transaction; --")
+                    .build();
+            CurrencyRequest currency = CurrencyRequest.builder()
+                    .symbol("ADA")
+                    .metadata(metadata)
+                    .build();
+
+            SearchTransactionsRequest request = SearchTransactionsRequest.builder()
+                    .networkIdentifier(networkIdentifier)
+                    .currency(currency)
+                    .build();
+
+            // When & Then
+            assertThatThrownBy(() -> searchService.searchTransaction(request, 0L, 10L))
+                    .isInstanceOf(ApiException.class)
+                    .extracting("error.message")
+                    .isEqualTo("Invalid policy id");
+
+            verifyNoInteractions(ledgerSearchService);
+        }
+
+        @Test
+        void shouldAcceptValidPolicyId() {
+            // Given - valid 56-char hex policyId
+            String validPolicyId = "d97e36383ae494e72b736ace04080f2953934626376ee06cf84adeb4";
+            CurrencyMetadataRequest metadata = CurrencyMetadataRequest.builder()
+                    .policyId(validPolicyId)
+                    .build();
+            CurrencyRequest currency = CurrencyRequest.builder()
+                    .symbol("000de1404469616d6f6e64")
+                    .metadata(metadata)
+                    .build();
+
+            SearchTransactionsRequest request = SearchTransactionsRequest.builder()
+                    .networkIdentifier(networkIdentifier)
+                    .currency(currency)
+                    .build();
+
+            Page<BlockTx> emptyPage = new PageImpl<>(List.of());
+            when(ledgerSearchService.searchTransaction(
+                    any(), any(), any(), any(), any(), any(), any(), any(), any(), anyLong(), anyLong()
+            )).thenReturn(emptyPage);
+
+            // When
+            Page<BlockTransaction> result = searchService.searchTransaction(request, 0L, 10L);
+
+            // Then - should not throw, valid policyId passes validation
+            assertThat(result).isNotNull();
+            verify(ledgerSearchService).searchTransaction(
+                    any(), any(), any(), any(),
+                    argThat(c -> c != null && validPolicyId.equals(c.getPolicyId())),
+                    any(), any(), any(), any(), anyLong(), anyLong()
+            );
+        }
+
+        @Test
+        void shouldAcceptNullPolicyId() {
+            // Given - no metadata means no policyId
+            CurrencyRequest currency = CurrencyRequest.builder()
+                    .symbol("ADA")
+                    .build();
+
+            SearchTransactionsRequest request = SearchTransactionsRequest.builder()
+                    .networkIdentifier(networkIdentifier)
+                    .currency(currency)
+                    .build();
+
+            Page<BlockTx> emptyPage = new PageImpl<>(List.of());
+            when(ledgerSearchService.searchTransaction(
+                    any(), any(), any(), any(), any(), any(), any(), any(), any(), anyLong(), anyLong()
+            )).thenReturn(emptyPage);
+
+            // When
+            Page<BlockTransaction> result = searchService.searchTransaction(request, 0L, 10L);
+
+            // Then - null policyId should be accepted
+            assertThat(result).isNotNull();
+        }
+    }
+
+    @Nested
     class ValidateAndNormalizeSuccessStatusTests {
 
         @Test


### PR DESCRIPTION
## Summary

- **Added policyId validation to `SearchServiceImpl`** — the search/transactions endpoint was not validating `policyId` from currency metadata, while the account endpoint (`AccountServiceImpl`) already enforces a strict `^[0-9a-fA-F]{56}$` hex regex. This aligns both paths to use the same validation.
- **Hardened repository layer input handling** — replaced the quote-escaping approach in `BaseCurrencyConditionBuilder` with strict hex-only validation (`requireHex`), ensuring only safe values reach query construction regardless of the calling path.
- **Renamed parameters** from `escapedPolicyId`/`escapedSymbol` to `validatedPolicyId`/`validatedSymbol` in both PostgreSQL and H2 implementations to reflect the new validation approach.

## Changes

| File | Change |
|------|--------|
| `SearchServiceImpl.java` | Added `validatePolicyId()` method with same regex as `AccountServiceImpl` |
| `TxRepositoryCustomBase.java` | Replaced `String.replace("\"", "\\\"")` with `requireHex()` validation |
| `TxRepositoryPostgreSQLImpl.java` | Parameter rename only |
| `TxRepositoryH2Impl.java` | Parameter rename only |
| `SearchServiceImplTest.java` | 7 new tests for policyId validation (valid, null, too short, too long, non-hex, special chars, unsanitized input) |
| `BaseCurrencyConditionBuilderTest.java` | 12 new tests for repository-layer input validation |

## Test plan

- [x] All 70 unit tests pass (19 new + 51 existing)
- [ ] Verify search/transactions endpoint rejects malformed policyId with error code 4023
- [ ] Verify search/transactions endpoint still accepts valid 56-char hex policyId
- [ ] Verify account endpoint behavior is unchanged