### PR TITLE
test: add input validation tests for currency, address, and coin identifier

### DIFF
--- a/tests/data-endpoints/test_error_handling.py
+++ b/tests/data-endpoints/test_error_handling.py
@@ -1,10 +1,11 @@
 """
 Cross-cutting error handling tests for all Rosetta endpoints.
 
-Tests network_identifier validation errors across all endpoints:
-- Missing network_identifier entirely
-- Empty network_identifier object
-- Invalid network value
+Tests:
+- network_identifier validation errors across all endpoints
+- Currency input validation (policyId, symbol, token name)
+- Address validation
+- Coin identifier validation
 """
 
 import pytest
@@ -163,3 +164,150 @@ class TestInvalidNetworkIdentifier:
         assert error.get("retriable") is False, (
             f"{endpoint_name} should not be retriable"
         )
+
+
+@allure.feature("Error Handling")
+@allure.story("Currency Input Validation")
+class TestSearchCurrencyValidation:
+    """Validate that /search/transactions rejects malformed currency inputs (PR #726)."""
+
+    @pytest.mark.parametrize("payload", [
+        pytest.param("'}]') OR 1=1 --", id="jsonb_injection"),
+        pytest.param("'; DROP TABLE transaction; --", id="sql_drop_table"),
+        pytest.param("abcdef1234", id="too_short"),
+        pytest.param("g" * 56, id="non_hex_correct_length"),
+        pytest.param("a" * 57, id="too_long"),
+    ])
+    def test_search_rejects_malformed_policy_id(self, client, payload):
+        """Malformed policyId should return error 4023."""
+        response = client.search_transactions(
+            currency={"symbol": "ADA", "decimals": 6, "metadata": {"policyId": payload}}
+        )
+
+        assert response.status_code == 400, (
+            f"Expected 400 for policyId '{payload[:30]}...', got {response.status_code}"
+        )
+        error = response.json()
+        assert error["code"] == 4023
+        assert error["message"] == "Invalid policy id"
+
+    @pytest.mark.parametrize("payload", [
+        pytest.param("'; DROP TABLE transaction; --", id="sql_injection"),
+        pytest.param("' OR 1=1 --", id="sql_or_injection"),
+        pytest.param("not-hex!", id="special_chars"),
+        pytest.param("abc def", id="spaces"),
+    ])
+    def test_search_rejects_malformed_symbol(self, client, payload):
+        """Non-hex currency symbol should return error 5059."""
+        response = client.search_transactions(
+            currency={"symbol": payload, "decimals": 6}
+        )
+
+        assert response.status_code == 400, (
+            f"Expected 400 for symbol '{payload[:30]}', got {response.status_code}"
+        )
+        error = response.json()
+        assert error["code"] == 5059
+
+    @pytest.mark.slow
+    def test_search_accepts_valid_policy_id(self, client, network_data):
+        """Valid hex policyId with matching symbol should return 200 (positive control)."""
+        asset = network_data["assets"][0]
+
+        response = client.search_transactions(
+            currency={
+                "symbol": asset["symbol_hex"],
+                "decimals": asset["decimals"],
+                "metadata": {"policyId": asset["policy_id"]},
+            },
+            limit=1,
+        )
+
+        assert response.status_code == 200
+
+
+@allure.feature("Error Handling")
+@allure.story("Account Currency Validation")
+class TestAccountCurrencyValidation:
+    """Validate that /account/balance rejects malformed currency inputs."""
+
+    @pytest.mark.parametrize("payload", [
+        pytest.param("'; DROP TABLE transaction; --", id="sql_injection"),
+        pytest.param("abcdef", id="too_short"),
+    ])
+    def test_account_balance_rejects_malformed_policy_id(self, client, network_data, payload):
+        """Malformed policyId in currencies should return error 4023."""
+        response = client.account_balance(
+            account_identifier={"address": network_data["addresses"]["shelley_base"]},
+            currencies=[{"symbol": "aabbcc", "decimals": 0, "metadata": {"policyId": payload}}],
+        )
+
+        assert response.status_code == 400, (
+            f"Expected 400 for policyId '{payload[:30]}', got {response.status_code}"
+        )
+        assert response.json()["code"] == 4023
+
+    @pytest.mark.parametrize("payload", [
+        pytest.param("not-hex!", id="special_chars"),
+        pytest.param("Diamond", id="ascii_letters"),
+    ])
+    def test_account_balance_rejects_invalid_token_name(self, client, network_data, payload):
+        """Invalid token name (non-hex) should return error 4024."""
+        response = client.account_balance(
+            account_identifier={"address": network_data["addresses"]["shelley_base"]},
+            currencies=[{"symbol": payload, "decimals": 0}],
+        )
+
+        assert response.status_code == 400, (
+            f"Expected 400 for token name '{payload}', got {response.status_code}"
+        )
+        assert response.json()["code"] == 4024
+
+
+@allure.feature("Error Handling")
+@allure.story("Address Validation")
+class TestAddressValidation:
+    """Validate that account endpoints reject invalid addresses."""
+
+    def test_account_balance_rejects_invalid_address(self, client):
+        """Invalid bech32 address should return error 4015."""
+        response = client.account_balance(
+            account_identifier={"address": "not_a_valid_bech32_address"}
+        )
+
+        assert response.status_code == 500, (
+            f"Expected 500 (retriable) for invalid address, got {response.status_code}"
+        )
+        error = response.json()
+        assert error["code"] == 4015
+        assert error["retriable"] is True
+
+    def test_account_coins_rejects_invalid_address(self, client):
+        """Invalid bech32 address should return error 4015."""
+        response = client.account_coins(
+            account_identifier={"address": "not_a_valid_bech32_address"}
+        )
+
+        assert response.status_code == 500, (
+            f"Expected 500 (retriable) for invalid address, got {response.status_code}"
+        )
+        error = response.json()
+        assert error["code"] == 4015
+        assert error["retriable"] is True
+
+
+@allure.feature("Error Handling")
+@allure.story("Coin Identifier Validation")
+class TestCoinIdentifierValidation:
+    """Validate that /search/transactions handles malformed coin identifiers."""
+
+    @pytest.mark.skip(reason="Bug: coin_identifier without ':' causes ArrayIndexOutOfBoundsException (no ticket yet)")
+    def test_search_malformed_coin_identifier_no_separator(self, client):
+        """coin_identifier without ':' separator should return 400 with structured error."""
+        response = client.search_transactions(
+            coin_identifier={"identifier": "no_colon_here"}
+        )
+
+        assert response.status_code == 400
+        error = response.json()
+        assert "code" in error


### PR DESCRIPTION
## Summary

- Adds 4 test classes to `test_error_handling.py` covering input validation across endpoints
- 16 passing parametrized cases + 1 skipped (documents a bug)
- Tests injection payloads, structural validation, and positive controls

## Test classes

| Class | Endpoint | What it tests | Error codes |
|---|---|---|---|
| `TestSearchCurrencyValidation` | `/search/transactions` | policyId injection/structural, symbol non-hex, valid positive control | 4023, 5059 |
| `TestAccountCurrencyValidation` | `/account/balance` | policyId and token name rejection | 4023, 4024 |
| `TestAddressValidation` | `/account/balance`, `/account/coins` | invalid bech32 address | 4015 |
| `TestCoinIdentifierValidation` | `/search/transactions` | malformed coin_identifier without `:` separator (skipped, bug) | - |

## Test plan

- [x] All 16 active tests pass against preprod with PR #726 images
- [x] Coin identifier test correctly skipped with reason
- [x] Verify PR workflow picks up new tests (marked `@pytest.mark.pr`)