### PR TITLE
fix: separate InterruptedException from IOException in YaciHttpGatewayImpl

### DIFF
--- a/api/src/main/java/org/cardanofoundation/rosetta/client/YaciHttpGatewayImpl.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/client/YaciHttpGatewayImpl.java
@@ -65,11 +65,12 @@ public class YaciHttpGatewayImpl implements YaciHttpGateway {
             } else {
                 throw ExceptionFactory.gatewayError(false);
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
             log.error("Error during yaci-indexer HTTP request", e);
-
             Thread.currentThread().interrupt();
-
+            throw ExceptionFactory.gatewayError(true);
+        } catch (IOException e) {
+            log.error("Error during yaci-indexer HTTP request", e);
             throw ExceptionFactory.gatewayError(true);
         }
     }
@@ -100,11 +101,12 @@ public class YaciHttpGatewayImpl implements YaciHttpGateway {
             } else {
                 throw ExceptionFactory.gatewayError(false);
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
             log.error("Error during yaci-indexer peers HTTP request", e);
-
             Thread.currentThread().interrupt();
-
+            throw ExceptionFactory.gatewayError(true);
+        } catch (IOException e) {
+            log.error("Error during yaci-indexer peers HTTP request", e);
             throw ExceptionFactory.gatewayError(true);
         }
     }


### PR DESCRIPTION
## Summary

- Split the combined `catch (IOException | InterruptedException)` into separate catch blocks in `YaciHttpGatewayImpl`
- `Thread.currentThread().interrupt()` is now only called for `InterruptedException`, not for `IOException`

## Problem

When the yaci-indexer HTTP endpoint is unreachable (e.g. during initial sync), `getDiscoveredPeers()` throws an `IOException`. The combined catch block called `Thread.currentThread().interrupt()` for both exception types, leaving the request thread in interrupted state. With `REMOVE_SPENT_UTXOS=true`, the subsequent `findOldestBlockIdentifier` DB query hit the interrupted flag, causing JDBC to close the socket and fail with `Unable to rollback against JDBC Connection`.

## Testing

Tested on three K3s servers (preprod, mainnet, snapshot) with `REMOVE_SPENT_UTXOS=true` and fresh postgres. Before the fix, the API failed with JDBC errors within minutes. After the fix, the API responds correctly while the indexer is syncing.

Closes #732