### PR TITLE
fix: bump yaci to 0.4.1 to fix chain sync on blocks with >23 txs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <version.swagger-annotations>2.2.8</version.swagger-annotations>
         <version.log4j>2.20.0</version.log4j>
         <version.client-lib>0.7.1</version.client-lib>
-        <version.yaci>0.4.0</version.yaci>
+        <version.yaci>0.4.1</version.yaci>
         <version.commons-io>2.14.0</version.commons-io>
         <version.javax-validation-api>2.0.1.Final</version.javax-validation-api>
         <version.findsecbugs-plugin>1.13.0</version.findsecbugs-plugin>


### PR DESCRIPTION
## Summary
- Bumps `version.yaci` from `0.4.0` to `0.4.1` in the root `pom.xml`.
- Pulls in the upstream fix for a CBOR parsing error on blocks encoded with definite-length arrays (>23 txs), which broke chain sync as reproduced on preview.
- Also picks up configurable `TipFinder` timeouts.

## Upstream changes
See [yaci v0.4.1 release](https://github.com/bloxbean/yaci/releases/tag/v0.4.1):
- [PR #149](https://github.com/bloxbean/yaci/pull/149) — Fix CBOR parsing error for blocks with definite-length arrays (>23 txs)
- [PR #133](https://github.com/bloxbean/yaci/pull/133) — Configurable timeouts in `TipFinder`

## Test plan
- [ ] `mvn clean install` builds successfully
- [ ] API module starts and connects to a Cardano node
- [ ] Chain sync progresses past blocks with >23 transactions on preview without CBOR parse errors