### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/.env.IntegrationTest
+++ b/.env.IntegrationTest
@@ -44,7 +44,7 @@ ANCILLARY_VERIFICATION_KEY=
  
 
 ## Release version (used for API and Indexer docker image tags)
-RELEASE_VERSION=2.1.1
+RELEASE_VERSION=2.1.2
 
 ## Api env
 API_SPRING_PROFILES_ACTIVE=online

--- a/.env.docker-compose
+++ b/.env.docker-compose
@@ -44,7 +44,7 @@ GENESIS_VERIFICATION_KEY=
 ANCILLARY_VERIFICATION_KEY=
 
 ## Release version (used for API and Indexer docker image tags)
-RELEASE_VERSION=2.1.1
+RELEASE_VERSION=2.1.2
 
 ## Api env
 # staging, h2, test. Additional profiles: mempool (if mempool should be activated)

--- a/.env.docker-compose-preprod
+++ b/.env.docker-compose-preprod
@@ -44,7 +44,7 @@ GENESIS_VERIFICATION_KEY=
 ANCILLARY_VERIFICATION_KEY=
 
 ## Release version (used for API and Indexer docker image tags)
-RELEASE_VERSION=2.1.1
+RELEASE_VERSION=2.1.2
 
 ## Api env
 # staging, h2, test. Additional profiles: mempool (if mempool should be activated)

--- a/.env.h2
+++ b/.env.h2
@@ -24,7 +24,7 @@ CARDANO_NODE_SUBMIT_HOST=localhost
 NODE_SUBMIT_API_PORT=8090
 
 ## Release version (used for API and Indexer docker image tags)
-RELEASE_VERSION=2.1.1
+RELEASE_VERSION=2.1.2
 
 ## Api env
 API_SPRING_PROFILES_ACTIVE=h2

--- a/.env.h2-testdata
+++ b/.env.h2-testdata
@@ -24,7 +24,7 @@ CARDANO_NODE_SUBMIT_HOST=localhost
 NODE_SUBMIT_API_PORT=8090
 
 ## Release version (used for API and Indexer docker image tags)
-RELEASE_VERSION=2.1.1
+RELEASE_VERSION=2.1.2
 
 ## Api env
 API_SPRING_PROFILES_ACTIVE=h2

--- a/docs/docs/install-and-deploy/env-vars.md
+++ b/docs/docs/install-and-deploy/env-vars.md
@@ -63,7 +63,7 @@ Hardware profile files should be used **in combination** with a base `.env.docke
 | `AGGREGATOR_ENDPOINT`                         | Mithril aggregator endpoint (uses default if not set)                 | (empty)                                | added in release 1.0.0  |
 | `GENESIS_VERIFICATION_KEY`                    | Mithril genesis verification key (uses default if not set)            | (empty)                                | added in release 1.0.0  |
 | `ANCILLARY_VERIFICATION_KEY`                  | Mithril ancillary verification key (uses default if not set)          | (empty)                                | added in release 1.2.9  |
-| `RELEASE_VERSION`                             | Docker image tag for API and Indexer images                           | 2.1.1                                  | added in release 2.0.0  |
+| `RELEASE_VERSION`                             | Docker image tag for API and Indexer images                           | 2.1.2                                  | added in release 2.0.0  |
 | `API_SPRING_PROFILES_ACTIVE`                  | API spring profile                                                    | staging                                | added in release 1.0.0  |
 | `API_PORT`                                    | Rosetta API exposed port                                              | 8082                                   | added in release 1.0.0  |
 | `PRINT_EXCEPTION`                             | Print stack traces in error responses                                 | true                                   | added in release 1.0.0  |

--- a/docs/docs/install-and-deploy/kubernetes/deployment.md
+++ b/docs/docs/install-and-deploy/kubernetes/deployment.md
@@ -268,7 +268,7 @@ helm upgrade rosetta helm/cardano-rosetta-java \
   -f helm/cardano-rosetta-java/values.yaml \
   -f helm/cardano-rosetta-java/values-k3s.yaml \
   "--set=global.db.password=${DB_PASSWORD}" \
-  --set global.releaseVersion="2.1.1" \
+  --set global.releaseVersion="2.1.2" \
   -n cardano 2>&1 | grep -v "walk.go"
 ```
 

--- a/docs/docs/install-and-deploy/kubernetes/helm-values.md
+++ b/docs/docs/install-and-deploy/kubernetes/helm-values.md
@@ -17,7 +17,7 @@ These values are shared across all subcharts via `global.*`.
 |-------|---------|--------------------------|-------------|
 | `global.network` | `mainnet` | `NETWORK` | Blockchain network: `mainnet`, `preprod`, `preview` |
 | `global.protocolMagic` | `"764824073"` | `PROTOCOL_MAGIC` | Cardano protocol magic number (always a quoted string to prevent scientific notation) |
-| `global.releaseVersion` | `"2.1.1"` | `RELEASE_VERSION` | Docker image tag for API and indexer |
+| `global.releaseVersion` | `"2.1.2"` | `RELEASE_VERSION` | Docker image tag for API and indexer |
 | `global.cardanoNodeVersion` | `"10.5.4"` | `CARDANO_NODE_VERSION` | Cardano node image tag |
 | `global.pgVersionTag` | `REL_18_0` | `PG_VERSION_TAG` | PostgreSQL image tag |
 | `global.mithrilVersion` | `2543.1-hotfix` | `MITHRIL_VERSION` | Mithril client image tag |

--- a/helm/cardano-rosetta-java/values.yaml
+++ b/helm/cardano-rosetta-java/values.yaml
@@ -4,7 +4,7 @@
 global:
   network: mainnet
   protocolMagic: "764824073"
-  releaseVersion: "2.1.1"
+  releaseVersion: "2.1.2"
   cardanoNodeVersion: "10.5.4"
   pgVersionTag: "REL_18_0"
   mithrilVersion: "2543.1-hotfix"

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </licenses>
 
     <properties>
-        <revision>2.1.1</revision>
+        <revision>2.1.2</revision>
         <java.version>24</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.spring-boot>3.5.0</version.spring-boot>

--- a/tests/integration/golden_examples/rosetta_java/data/network/network_options_operation_types.json
+++ b/tests/integration/golden_examples/rosetta_java/data/network/network_options_operation_types.json
@@ -13,7 +13,7 @@
     "version": {
       "rosetta_version": "1.4.13",
       "node_version": "10.5.4",
-      "middleware_version": "2.1.1",
+      "middleware_version": "2.1.2",
       "metadata": {}
     },
     "allow": {


### PR DESCRIPTION
Bumps all version references from `2.1.1` to `2.1.2` across the 11 places the release version appears.