### PR TITLE
docs: document index-applier 72h deadline and recovery procedure

### DIFF
--- a/docs/docs/advanced-configuration/index-management.md
+++ b/docs/docs/advanced-configuration/index-management.md
@@ -30,6 +30,12 @@ The index-applier container:
 
 **Performance:** Index creation takes approximately 6 hours on mainnet.
 
+:::note
+
+On Kubernetes, the index-applier Job has a 72-hour deadline (`activeDeadlineSeconds: 259200`). See the [Deployment Runbook](/docs/install-and-deploy/kubernetes/deployment#troubleshooting) if the API stays stuck at `APPLYING_INDEXES`.
+
+:::
+
 ## Customizing Indexes
 
 To add custom indexes for your use case:

--- a/docs/docs/install-and-deploy/kubernetes/deployment.md
+++ b/docs/docs/install-and-deploy/kubernetes/deployment.md
@@ -325,6 +325,7 @@ kubectl delete pvc --all -n cardano
 | `ImagePullBackOff` | Wrong image tag | Check `global.releaseVersion` in values |
 | Port-forward not reachable from remote | Bound to 127.0.0.1 | Add `--address 0.0.0.0` to `kubectl port-forward` |
 | cardano-node restart loop after reboot | Startup probe too short for ImmutableDB validation | `startupProbe.failureThreshold: 720` (3 hours); force-delete pod if StatefulSet update is blocked |
+| API stuck at `APPLYING_INDEXES`, never reaches `LIVE` | index-applier Job killed by `activeDeadlineSeconds: 259200` (72h) | Delete the failed Job (`kubectl delete job rosetta-index-applier -n cardano`) and re-run `helm upgrade` |
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the index-applier Kubernetes Job `activeDeadlineSeconds: 259200` (72h) behavior and recovery procedure across two locations:

### Changes

**`deployment.md`** (Troubleshooting table)
- New row: symptom "API stuck at `APPLYING_INDEXES`, never reaches `LIVE`" → cause → resolution

**`index-management.md`** (Automatic Index Application section)
- Short `:::note` mentioning the Kubernetes 72h deadline with a link to the Deployment Runbook

### Context

Sync from genesis on mainnet can exceed the 3-day Job deadline. When this happens, Kubernetes kills the Job and the API stays frozen at `APPLYING_INDEXES`. The recovery is: delete the failed Job and re-run `helm upgrade`. The apply-indexes script handles cleanup of partially-created indexes automatically.