### PR TITLE
docs: add build-from-source page and fix stale architecture references

### DIFF
--- a/docs/docs/core-concepts/architecture.md
+++ b/docs/docs/core-concepts/architecture.md
@@ -22,9 +22,7 @@ _Figure 1: Context Diagram showing system boundaries and external dependencies_
 The specific changes in this implementation can be found in [Cardano Specific API Additions](./cardano-addons.md)
 
 :::tip Getting Started
-To use this Rosetta API for Cardano you can build the project from source or use the pre-built docker image.
-
-[Docker Images](https://hub.docker.com/r/cardanofoundation/cardano-rosetta-java)
+See [Building from Source](../install-and-deploy/build-from-source) to build Docker images locally, or [Docker Compose](../install-and-deploy/docker) to deploy with pre-built images.
 :::
 
 The solution provides Construction API (mutation of data) and Data API (read data) according to the Rosetta spec accessible via an REST API that allows you to interact with the Cardano blockchain.
@@ -46,69 +44,4 @@ For Data API requests, the Rosetta API App reads this indexed data directly from
 
 _Figure 2: Component Diagram showing internal architecture_
 
-## Key Components
-
-### Cardano Node
-
-The Cardano Node is a full implementation of the Cardano blockchain protocol that connects to the Cardano network, validates transactions and blocks, and maintains the blockchain state.
-
-:::info
-**Version**: 10.5.3 (configurable via build args)  
-**Built with**: GHC 9.6.7 and Cabal 3.12.1.0  
-**Runtime socket path**: `/node/node.socket`  
-**Data directory**: `/node/db`  
-**Network options**: mainnet, preprod, preview, devkit  
-**Configuration files**: stored in `/config` directory
-:::
-
-The node is the foundation of the system, providing blockchain data to the indexer and validating/submitting transactions to the network.
-
-### Cardano Submit API
-
-The Cardano Submit API provides a REST interface for submitting transactions to the Cardano network.
-
-:::info
-**Port**: 8090 (configurable)  
-**Configuration file**: `/cardano-submit-api-config/cardano-submit-api.yaml`  
-**Connects to**: Cardano Node via its socket  
-**Functionality**: Exposes HTTP endpoints for transaction submission  
-**Startup**: Started by the entrypoint script after node initialization
-:::
-
-This component provides a standard interface for transaction submission, allowing the Rosetta API to submit user transactions to the Cardano network.
-
-### Yaci Indexer App
-
-The YACI (Yet Another Cardano Indexer) Indexer processes blockchain data from the Cardano Node and stores it in a structured format in the PostgreSQL database.
-
-:::info
-**Base library**: yaci version 0.3.5  
-**API port**: 9095  
-:::
-
-The indexer features modular components that support different aspects of the Cardano blockchain, including blocks, transactions, UTXOs, staking, and epoch data. It handles efficient data processing with configurable pruning options to manage database size.
-
-### Database
-
-PostgreSQL database stores indexed blockchain data in a structured format optimized for API queries. While YACI store supports multiple database options, PostgreSQL is the default and recommended choice for this implementation.
-
-:::info
-**Version**: 14 (configurable)  
-**Schema name**: Based on network (e.g., mainnet, preprod)  
-**Default credentials**: Username: rosetta_db_admin, Password: configurable  
-**Data directory**: `/var/lib/postgresql/data` (mapped to `${DB_PATH}` on the host)
-:::
-
-Configurable performance parameters through [hardware profiles](../install-and-deploy/hardware-profiles).
-
-### Rosetta API App
-
-The Rosetta API implements the Mesh (formerly Rosetta) API specification, providing a standardized interface for blockchain interaction. This application handles [Data API](https://docs.cloud.coinbase.com/rosetta/docs/data-api-overview) requests by reading aggregated data from the database, and manages [Construction API](https://docs.cloud.coinbase.com/rosetta/docs/construction-api-overview) requests by constructing and submitting transactions to the Cardano Node using the [cardano-client-lib](https://github.com/bloxbean/cardano-client-lib).
-
-:::info
-**Implements**: Rosetta API version 1.4.13  
-**Built with**: Spring Boot 3.2.3  
-**Port**: 8082  
-**Java version**: 21  
-**Operation modes**: Online (with node connection), Offline (transaction construction only)
-:::
+For a complete breakdown of all containers, ports, and their lifecycle, see the [Boot Sequence](../install-and-deploy/boot-sequence#components) page.

--- a/docs/docs/install-and-deploy/build-from-source.md
+++ b/docs/docs/install-and-deploy/build-from-source.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 5
+title: Building from Source
+description: Build Docker images locally and import them into K3s for Helm deployments
+---
+
+# Building from Source
+
+Build Docker images locally from the repository using Docker Compose. For Docker Compose deployments, the images are used directly. For Kubernetes (K3s) deployments, the images need to be imported into containerd.
+
+## Prerequisites
+
+- Docker with Compose plugin
+- Clone of `cardano-rosetta-java` checked out to the target branch or tag
+- A valid `.env` file (see [Environment Variables](./env-vars) for details)
+
+## Build all images
+
+```bash
+cd cardano-rosetta-java
+docker compose build
+```
+
+This builds all service images defined in the compose files. Image tags are derived from your `.env`:
+
+| Image | Tag source |
+|---|---|
+| `cardanofoundation/cardano-rosetta-java-api` | `RELEASE_VERSION` |
+| `cardanofoundation/cardano-rosetta-java-indexer` | `RELEASE_VERSION` |
+| `cardanofoundation/cardano-rosetta-java-cardano-node` | `CARDANO_NODE_VERSION` |
+| `cardanofoundation/cardano-rosetta-java-postgres` | `PG_VERSION_TAG` |
+| `cardanofoundation/cardano-rosetta-java-mithril` | `MITHRIL_VERSION` |
+
+To build a single service:
+
+```bash
+docker compose build api
+docker compose build cardano-node
+```
+
+## Import images into K3s
+
+K3s uses containerd, not Docker. Images built with Docker need to be exported and imported before they can be used by Helm:
+
+```bash
+docker save \
+  cardanofoundation/cardano-rosetta-java-api:<RELEASE_VERSION> \
+  cardanofoundation/cardano-rosetta-java-indexer:<RELEASE_VERSION> \
+  cardanofoundation/cardano-rosetta-java-cardano-node:<CARDANO_NODE_VERSION> \
+  cardanofoundation/cardano-rosetta-java-postgres:<PG_VERSION_TAG> \
+  cardanofoundation/cardano-rosetta-java-mithril:<MITHRIL_VERSION> \
+  | sudo k3s ctr images import -
+```
+
+The default `imagePullPolicy` is `IfNotPresent`, so K3s uses the locally imported images instead of pulling from the registry.
+
+:::warning Replacing images with the same tag
+
+If you rebuild an image and import it with a tag that already exists in K3s, the old cached image is kept. You must remove the old image first:
+
+```bash
+sudo k3s ctr images rm docker.io/cardanofoundation/cardano-rosetta-java-api:<TAG>
+```
+
+Then import the new image. You can verify the correct image is loaded by checking the SHA:
+
+```bash
+sudo k3s ctr images ls | grep cardano-rosetta-java-api
+```
+
+:::
+
+## Next steps
+
+- [Deploy with Docker Compose](./docker)
+- [Deploy with Kubernetes (K3s)](./kubernetes/deployment)

--- a/docs/docs/install-and-deploy/docker.md
+++ b/docs/docs/install-and-deploy/docker.md
@@ -17,6 +17,12 @@ Before you begin, ensure you have the following installed:
 - Java 24
 - For integration tests: Node 14+
 
+:::note
+
+To build Docker images from source instead of pulling the pre-built ones, see [Building from Source](./build-from-source).
+
+:::
+
 ## Deployment
 
 ### Using Docker Compose

--- a/docs/docs/install-and-deploy/kubernetes/deployment.md
+++ b/docs/docs/install-and-deploy/kubernetes/deployment.md
@@ -38,6 +38,12 @@ description: This runbook covers deploying and operating **Cardano Rosetta Java*
 - `jq` (for status checks)
 - K3s or a managed K8s cluster (EKS, GKE, AKS)
 
+:::note
+
+To build and import Docker images locally into K3s instead of pulling from the registry, see [Building from Source](../build-from-source#import-images-into-k3s).
+
+:::
+
 ### Network
 - Outbound TCP 3001 — cardano-node peer-to-peer (N2N)
 - Outbound HTTPS — Mithril snapshot download + genesis key fetch from GitHub


### PR DESCRIPTION
## Summary

- New **build-from-source.md** page covering `docker compose build`, K3s image import, and same-tag image replacement
- Removed stale **Key Components** section from architecture.md (outdated versions: Cardano Node 10.5.3, yaci 0.3.5, Java 21); replaced with link to **[Boot Sequence](../install-and-deploy/boot-sequence#components)** which is the canonical source
- Fixed Getting Started tip to link build-from-source and docker.md instead of Docker Hub
- Added cross-links to build-from-source in docker.md and deployment.md Prerequisites