### PR TITLE
docs: fix duplicated trailing column in env-vars table

### DIFF
--- a/docs/docs/install-and-deploy/env-vars.md
+++ b/docs/docs/install-and-deploy/env-vars.md
@@ -50,7 +50,7 @@ Hardware profile files should be used **in combination** with a base `.env.docke
 | `DB_PATH`                                     | Database path                                                         | /opt/cardano-rosetta-java/mainnet/sql_data | added in release 1.0.0  |
 | `CARDANO_NODE_HOST`                           | Cardano node host                                                     | cardano-node                           | added in release 1.0.0  |
 | `CARDANO_NODE_PORT`                           | Cardano node port                                                     | 3001                                   | added in release 1.0.0  |
-| `CARDANO_NODE_VERSION`                        | Cardano node version                                                  | 11.0.1                                 | added in release 1.0.0  |                                 | added in release 1.0.0  |
+| `CARDANO_NODE_VERSION`                        | Cardano node version                                                  | 11.0.1                                 | added in release 1.0.0  |
 | `CARDANO_NODE_SUBMIT_HOST`                    | Cardano node submit API host                                          | cardano-submit-api                     | added in release 1.0.0  |
 | `NODE_SUBMIT_API_PORT`                        | Cardano node submit API port                                          | 8090                                   | added in release 1.0.0  |
 | `CARDANO_NODE_DIR`                            | Cardano node base directory                                           | /node                                  | added in release 1.0.0  |
@@ -58,7 +58,7 @@ Hardware profile files should be used **in combination** with a base `.env.docke
 | `CARDANO_NODE_DB`                             | Cardano node db path                                                  | /node/db                               | added in release 1.0.0  |
 | `CARDANO_CONFIG`                              | Cardano node config path (host side)                                  | ./config/node/mainnet                  | added in release 1.0.0  |
 | `CARDANO_CONFIG_CONTAINER_PATH`               | Cardano node config path inside container                             | /config                                | added in release 2.0.0  |
-| `MITHRIL_VERSION`                             | Mithril client version                                                | 2617.0                                 | added in release 1.2.9  |                          | added in release 1.2.9  |
+| `MITHRIL_VERSION`                             | Mithril client version                                                | 2617.0                                 | added in release 1.2.9  |
 | `SNAPSHOT_DIGEST`                             | Mithril snapshot digest                                               | latest                                 | added in release 1.0.0  |
 | `AGGREGATOR_ENDPOINT`                         | Mithril aggregator endpoint (uses default if not set)                 | (empty)                                | added in release 1.0.0  |
 | `GENESIS_VERIFICATION_KEY`                    | Mithril genesis verification key (uses default if not set)            | (empty)                                | added in release 1.0.0  |


### PR DESCRIPTION
## Summary
The `CARDANO_NODE_VERSION` and `MITHRIL_VERSION` rows in the env-vars reference table (`docs/docs/install-and-deploy/env-vars.md`) had a duplicated trailing `| added in release X |` column, introduced during the 2.2.0 hard-fork prep (#741). This broke the Markdown table layout (extra cells on those two rows).

## Change
- Removed the duplicated trailing column from both rows. No content/value changes — `CARDANO_NODE_VERSION` stays `11.0.1`, `MITHRIL_VERSION` stays `2617.0`.