### PR TITLE
feat: add 5s cache for sync status verification

### DIFF
--- a/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/NetworkServiceImpl.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/NetworkServiceImpl.java
@@ -168,7 +168,7 @@ public class NetworkServiceImpl implements NetworkService {
       networkStatusBuilder.oldestBlock(oldestBlockIdentifier);
     }
 
-    syncStatusService.calculateSyncStatus(latestBlock).ifPresent(networkStatusBuilder::syncStatus);
+    syncStatusService.getSyncStatus().ifPresent(networkStatusBuilder::syncStatus);
 
     return networkStatusBuilder.build();
   }
@@ -187,8 +187,7 @@ public class NetworkServiceImpl implements NetworkService {
 
   @Override
   public void verifySyncStatus() {
-    BlockIdentifierExtended latestBlock = ledgerBlockService.findLatestBlockIdentifier();
-    SyncStatus syncStatus = syncStatusService.calculateSyncStatus(latestBlock)
+    SyncStatus syncStatus = syncStatusService.getSyncStatus()
         .orElseThrow(ExceptionFactory::indexerNotReady);
     if (!SyncStage.LIVE.getValue().equals(syncStatus.getStage())) {
       throw ExceptionFactory.indexerNotReady();

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusHealthIndicator.java
@@ -1,7 +1,9 @@
 package org.cardanofoundation.rosetta.api.network.service;
 
 import lombok.RequiredArgsConstructor;
-import org.cardanofoundation.rosetta.api.block.service.LedgerBlockService;
+import java.util.Optional;
+import org.openapitools.client.model.SyncStatus;
+
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
@@ -35,13 +37,19 @@ import javax.annotation.Nullable;
 public class SyncStatusHealthIndicator implements HealthIndicator {
 
     private final SyncStatusService syncStatusService;
-    private final LedgerBlockService ledgerBlockService;
+
 
     @Override
     @Nullable
     public Health health() {
-        var latestBlock = ledgerBlockService.findLatestBlockIdentifier();
-        var syncStatusOpt = syncStatusService.calculateSyncStatus(latestBlock);
+        Optional<SyncStatus> syncStatusOpt;
+        try {
+            syncStatusOpt = syncStatusService.getSyncStatus();
+        } catch (Exception e) {
+            return Health.outOfService()
+                    .withDetail("reason", "Sync status cannot be determined — " + e.getMessage())
+                    .build();
+        }
 
         if (syncStatusOpt == null || syncStatusOpt.isEmpty()) {
             return Health.outOfService()

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusHealthIndicator.java
@@ -42,14 +42,7 @@ public class SyncStatusHealthIndicator implements HealthIndicator {
     @Override
     @Nullable
     public Health health() {
-        Optional<SyncStatus> syncStatusOpt;
-        try {
-            syncStatusOpt = syncStatusService.getSyncStatus();
-        } catch (Exception e) {
-            return Health.outOfService()
-                    .withDetail("reason", "Sync status cannot be determined — " + e.getMessage())
-                    .build();
-        }
+        Optional<SyncStatus> syncStatusOpt = syncStatusService.getSyncStatus();
 
         if (syncStatusOpt == null || syncStatusOpt.isEmpty()) {
             return Health.outOfService()

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusService.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusService.java
@@ -9,6 +9,12 @@ import org.openapitools.client.model.SyncStatus;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import org.cardanofoundation.rosetta.api.block.service.LedgerBlockService;
+import org.cardanofoundation.rosetta.common.exception.ExceptionFactory;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import java.util.List;
@@ -26,6 +32,7 @@ public class SyncStatusService {
     private final OfflineSlotService offlineSlotService;
     private final SlotRangeChecker slotRangeChecker;
     private final IndexCreationMonitor indexCreationMonitor;
+    private final LedgerBlockService ledgerBlockService;
 
     @Value("${cardano.rosetta.SYNC_GRACE_SLOTS_COUNT:200}")
     private int allowedSlotsDelta;
@@ -136,5 +143,28 @@ public class SyncStatusService {
                 .stage(stage.getValue())
                 .build();
         });
+    }
+
+    /**
+     * Gets the sync status of the indexer. This is cached for 5 seconds to prevent
+     * redundant database checks on every request.
+     *
+     * @return an Optional containing the SyncStatus of the indexer if available, empty otherwise
+     */
+    @Cacheable(value = "syncStatusCache", unless = "#result == null")
+    public Optional<SyncStatus> getSyncStatus() {
+        log.info("[SyncStatusService] Cache miss - querying sync status from DB");
+        BlockIdentifierExtended latestBlock = ledgerBlockService.findLatestBlockIdentifier();
+        return calculateSyncStatus(latestBlock);
+    }
+
+    /**
+     * Periodically evicts all sync status entries from the cache.
+     * The rate is configurable via properties, defaulting to 5 seconds.
+     */
+    @Scheduled(fixedRateString = "${cardano.rosetta.sync-status-cache-ttl-ms:5000}")
+    @CacheEvict(value = "syncStatusCache", allEntries = true)
+    public void evictSyncStatusCache() {
+        log.trace("[SyncStatusService] Evicting syncStatusCache");
     }
 }

--- a/api/src/main/java/org/cardanofoundation/rosetta/config/CacheConfig.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/config/CacheConfig.java
@@ -17,7 +17,7 @@ public class CacheConfig {
 
   @Bean
   public ConcurrentMapCacheManager cacheManager() {
-    return new ConcurrentMapCacheManager("protocolParamsCache");
+    return new ConcurrentMapCacheManager("protocolParamsCache", "syncStatusCache");
   }
 
   //a cache for token metadata from token registry

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/NetworkServiceSyncStatusTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/NetworkServiceSyncStatusTest.java
@@ -43,47 +43,40 @@ class NetworkServiceSyncStatusTest {
 
     @Test
     void verifySyncStatus_Live_DoesNotThrow() {
-        when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
-        
         SyncStatus syncStatus = SyncStatus.builder()
                 .stage("LIVE")
                 .synced(true)
                 .build();
-        when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+        when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
         assertDoesNotThrow(() -> networkService.verifySyncStatus());
     }
 
     @Test
     void verifySyncStatus_Syncing_ThrowsIndexerNotReady() {
-        when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
-        
         SyncStatus syncStatus = SyncStatus.builder()
                 .stage("SYNCING")
                 .synced(false)
                 .build();
-        when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+        when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
         assertThrows(ApiException.class, () -> networkService.verifySyncStatus());
     }
 
     @Test
     void verifySyncStatus_ApplyingIndexes_ThrowsIndexerNotReady() {
-        when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
-        
         SyncStatus syncStatus = SyncStatus.builder()
                 .stage("APPLYING_INDEXES")
                 .synced(false)
                 .build();
-        when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+        when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
         assertThrows(ApiException.class, () -> networkService.verifySyncStatus());
     }
 
     @Test
     void verifySyncStatus_EmptySyncStatus_ThrowsIndexerNotReady() {
-        when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
-        when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.empty());
+        when(syncStatusService.getSyncStatus()).thenReturn(Optional.empty());
 
         assertThrows(ApiException.class, () -> networkService.verifySyncStatus());
     }

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusHealthIndicatorTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusHealthIndicatorTest.java
@@ -1,8 +1,5 @@
 package org.cardanofoundation.rosetta.api.network.service;
 
-import org.cardanofoundation.rosetta.api.block.model.domain.BlockIdentifierExtended;
-import org.cardanofoundation.rosetta.api.block.service.LedgerBlockService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,23 +22,8 @@ class SyncStatusHealthIndicatorTest {
     @Mock
     private SyncStatusService syncStatusService;
 
-    @Mock
-    private LedgerBlockService ledgerBlockService;
-
     @InjectMocks
     private SyncStatusHealthIndicator indicator;
-
-    private BlockIdentifierExtended latestBlock;
-
-    @BeforeEach
-    void setUp() {
-        latestBlock = BlockIdentifierExtended.builder()
-                .slot(100_000_000L)
-                .number(10_000_000L)
-                .hash("abc123")
-                .build();
-        when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
-    }
 
     @Nested
     @DisplayName("When sync stage is LIVE")
@@ -56,7 +38,7 @@ class SyncStatusHealthIndicatorTest {
                     .currentIndex(100_000_000L)
                     .targetIndex(100_000_050L)
                     .build();
-            when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+            when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
             Health health = indicator.health();
 
@@ -72,7 +54,7 @@ class SyncStatusHealthIndicatorTest {
                     .currentIndex(100_000_000L)
                     .targetIndex(100_000_050L)
                     .build();
-            when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+            when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
             Health health = indicator.health();
 
@@ -97,7 +79,7 @@ class SyncStatusHealthIndicatorTest {
                     .currentIndex(50_000_000L)
                     .targetIndex(100_000_000L)
                     .build();
-            when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+            when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
             Health health = indicator.health();
 
@@ -113,7 +95,7 @@ class SyncStatusHealthIndicatorTest {
                     .currentIndex(50_000_000L)
                     .targetIndex(100_000_000L)
                     .build();
-            when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+            when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
             Health health = indicator.health();
 
@@ -136,7 +118,7 @@ class SyncStatusHealthIndicatorTest {
                     .currentIndex(100_000_000L)
                     .targetIndex(100_000_000L)
                     .build();
-            when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+            when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
             Health health = indicator.health();
 
@@ -152,7 +134,7 @@ class SyncStatusHealthIndicatorTest {
                     .currentIndex(100_000_000L)
                     .targetIndex(100_000_000L)
                     .build();
-            when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.of(syncStatus));
+            when(syncStatusService.getSyncStatus()).thenReturn(Optional.of(syncStatus));
 
             Health health = indicator.health();
 
@@ -161,27 +143,30 @@ class SyncStatusHealthIndicatorTest {
     }
 
     @Nested
-    @DisplayName("When sync status Optional is empty")
-    class WhenSyncStatusEmpty {
+    @DisplayName("When sync status Optional is empty or throws exception")
+    class WhenSyncStatusEmptyOrError {
 
         @Test
-        @DisplayName("health() returns OUT_OF_SERVICE status")
-        void returnsHealthOutOfService() {
-            when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.empty());
+        @DisplayName("health() returns OUT_OF_SERVICE status when empty")
+        void returnsHealthOutOfServiceWhenEmpty() {
+            when(syncStatusService.getSyncStatus()).thenReturn(Optional.empty());
 
             Health health = indicator.health();
 
             assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+            assertThat(health.getDetails()).containsKey("reason");
         }
 
         @Test
-        @DisplayName("health() includes a 'reason' detail explaining unavailability")
-        void includesReasonDetail() {
-            when(syncStatusService.calculateSyncStatus(latestBlock)).thenReturn(Optional.empty());
+        @DisplayName("health() returns OUT_OF_SERVICE status when service throws exception")
+        void returnsHealthOutOfServiceWhenThrows() {
+            when(syncStatusService.getSyncStatus()).thenThrow(new RuntimeException("DB offline"));
 
             Health health = indicator.health();
 
-            assertThat(health.getDetails()).containsKey("reason");
+            assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+            assertThat(health.getDetails().get("reason"))
+                    .isEqualTo("Sync status cannot be determined — DB offline");
         }
     }
 }

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusHealthIndicatorTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusHealthIndicatorTest.java
@@ -143,8 +143,8 @@ class SyncStatusHealthIndicatorTest {
     }
 
     @Nested
-    @DisplayName("When sync status Optional is empty or throws exception")
-    class WhenSyncStatusEmptyOrError {
+    @DisplayName("When sync status Optional is empty")
+    class WhenSyncStatusEmpty {
 
         @Test
         @DisplayName("health() returns OUT_OF_SERVICE status when empty")
@@ -155,18 +155,6 @@ class SyncStatusHealthIndicatorTest {
 
             assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
             assertThat(health.getDetails()).containsKey("reason");
-        }
-
-        @Test
-        @DisplayName("health() returns OUT_OF_SERVICE status when service throws exception")
-        void returnsHealthOutOfServiceWhenThrows() {
-            when(syncStatusService.getSyncStatus()).thenThrow(new RuntimeException("DB offline"));
-
-            Health health = indicator.health();
-
-            assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
-            assertThat(health.getDetails().get("reason"))
-                    .isEqualTo("Sync status cannot be determined — DB offline");
         }
     }
 }

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusServiceTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusServiceTest.java
@@ -17,7 +17,11 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
+import org.cardanofoundation.rosetta.api.block.service.LedgerBlockService;
+
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class SyncStatusServiceTest {
@@ -31,6 +35,9 @@ class SyncStatusServiceTest {
     @Mock
     private IndexCreationMonitor indexCreationMonitor;
 
+    @Mock
+    private LedgerBlockService ledgerBlockService;
+
     private SyncStatusService syncStatusService;
 
     private static final int ALLOWED_SLOTS_DELTA = 100;
@@ -40,7 +47,8 @@ class SyncStatusServiceTest {
         syncStatusService = new SyncStatusService(
             offlineSlotService,
             slotRangeChecker,
-            indexCreationMonitor
+            indexCreationMonitor,
+            ledgerBlockService
         );
         ReflectionTestUtils.setField(syncStatusService, "allowedSlotsDelta", ALLOWED_SLOTS_DELTA);
     }
@@ -184,6 +192,38 @@ class SyncStatusServiceTest {
             assertThat(result.get().getStage()).isEqualTo(SyncStage.SYNCING.getValue());
             assertThat(result.get().getTargetIndex()).isEqualTo(currentSlot);
             assertThat(result.get().getCurrentIndex()).isEqualTo(latestBlockSlot);
+        }
+    }
+
+    @Nested
+    @DisplayName("getSyncStatus tests")
+    class GetSyncStatusTests {
+
+        @Test
+        @DisplayName("Should query latest block and calculate sync status successfully")
+        void shouldQueryLatestBlockAndCalculateSyncStatus() {
+            // Given
+            long currentSlot = 1000L;
+            long latestBlockSlot = 990L;
+            BlockIdentifierExtended latestBlock = BlockIdentifierExtended.builder()
+                .slot(latestBlockSlot)
+                .build();
+
+            when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
+            when(offlineSlotService.getCurrentSlotBasedOnTime()).thenReturn(Optional.of(currentSlot));
+            when(slotRangeChecker.isSlotWithinEpsilon(currentSlot, latestBlockSlot, ALLOWED_SLOTS_DELTA))
+                .thenReturn(true);
+            when(indexCreationMonitor.isCreatingIndexes()).thenReturn(false);
+
+            // When
+            Optional<SyncStatus> resultOpt = syncStatusService.getSyncStatus();
+
+            // Then
+            assertThat(resultOpt).isPresent();
+            SyncStatus result = resultOpt.get();
+            assertThat(result.getSynced()).isTrue();
+            assertThat(result.getStage()).isEqualTo(SyncStage.LIVE.getValue());
+            verify(ledgerBlockService, times(1)).findLatestBlockIdentifier();
         }
     }
 }


### PR DESCRIPTION
Ref: #759 

Introduced a short-lived (5-second by default, configurable) cache for the indexer sync status verification.

Once the indexer transitions to the "LIVE" stage, subsequent status verifications (`verifySyncStatus()`) utilize the cached status instead of querying the database. This significantly reduces database load and prevents repetitive checks on high-frequency endpoints (such as `/block` and `/account/balance`) under heavy load.
