### PR TITLE
spike: enable n2c connection pooling in yaci-indexer

### DIFF
--- a/yaci-indexer/src/main/resources/application.properties
+++ b/yaci-indexer/src/main/resources/application.properties
@@ -150,6 +150,27 @@ store.continue-on-parse-error=${CONTINUE_PARSING_ON_ERROR:false}
 
 jobs.peer-discovery.enabled=${PEER_DISCOVERY:false}
 
+#####################################################################################################
+# N2C (Node-to-Client) connection pool
+#
+# The n2c local-state-query connection to the local Cardano node is used for stake-account reward
+# lookups (/account/balance for stake addresses), protocol parameter fetching and tx submission.
+# With pooling disabled (yaci-store default), every such call opens a fresh socket + n2c handshake
+# and tears it down afterwards. Pooling reuses warm connections and removes that per-request churn.
+#
+# NOTE: the "max total" key is store.cardano.n2c-pool-max-total (binds to n2cPoolMaxTotal). yaci-store's
+# own sample config uses n2c-max-total, which does NOT bind - do not copy that name.
+# Only takes effect when n2c is configured (n2c-socket / n2c-socat profiles).
+#
+# Upstream documentation:
+# https://store.yaci.xyz/docs/v2/stores/configuration#n2c-connection-pool-configuration
+#####################################################################################################
+store.cardano.n2c-pool-enabled=true
+store.cardano.n2c-pool-max-total=10
+store.cardano.n2c-pool-min-idle=2
+store.cardano.n2c-pool-max-idle=5
+store.cardano.n2c-pool-max-wait-in-millis=10000
+
 # disable local state for n2c governance for now
 #When enabled, yaci-store will periodically query the Cardano node's  current governance state via n2c protocol: proposal status, drep distribution,...
 #Before the  governance-aggr module was introduced, this was the only way to get the above governance data: proposal status,, drep distribution (voting power), current committee state...


### PR DESCRIPTION
## What

Enables yaci-store's **N2C (Node-to-Client) connection pool** in the yaci-indexer. The pool code already ships in the `yaci-store` dependency (`2.0.1`) but is **defaulted off** upstream — this just turns it on with fixed, tuned values.

Change is config-only, in `yaci-indexer/src/main/resources/application.properties`:

```properties
store.cardano.n2c-pool-enabled=true
store.cardano.n2c-pool-max-total=10
store.cardano.n2c-pool-min-idle=2
store.cardano.n2c-pool-max-idle=5
store.cardano.n2c-pool-max-wait-in-millis=10000
```

## Why

The yaci-indexer talks to the local node over **two independent protocols**:

- **N2N** (`CARDANO_NODE_HOST`/`PORT`) — the high-volume chain-sync/block-fetch stream that drives all block indexing. **Not touched by this change.**
- **N2C** (local socket, `n2c-socket`/`n2c-socat` profiles) — used for three on-demand paths:
  1. **Stake-account reward lookups** — `/account/balance` for a **stake address** issues a live `DelegationsAndRewardAccounts` local-state query to the node on **every request** (`AccountServiceImpl.getAccountInfo`). Payment-address balances come from the indexed Postgres UTXO data and do not use N2C.
  2. **Protocol parameter fetching** (Construction API).
  3. **Transaction submission** when routed through the local node rather than the cardano-submit-api sidecar.

With pooling disabled (the current default), every N2C request opens a fresh socket, performs the N2C handshake, runs the query, then tears the connection down. For deployments serving exchanges/wallets that poll account balances, the stake-reward path repeats this connect/handshake/teardown cycle on **every stake-address balance request**, causing needless connection churn against the node socket. Pooling reuses warm connections and removes that churn.

## Decisions

- **Hardcoded, not env-exposed.** These are internal tuning constants; operators should not mis-tune them, so no new environment variables were added.
- **Correct binding key.** Uses `store.cardano.n2c-pool-max-total` (binds to `n2cPoolMaxTotal`). yaci-store's own sample config documents this as `n2c-max-total`, which binds to a non-existent field and is silently ignored — that spelling is intentionally avoided, and the config comment calls this out.
- The config comment links to the upstream docs: https://store.yaci.xyz/docs/v2/stores/configuration#n2c-connection-pool-configuration

## Scope / risk

- Pool is only instantiated when N2C is configured (`n2c-socket` / `n2c-socat` profiles); no-op otherwise.
- No Java changes, no API changes, no new dependencies.