### PR TITLE
fix: don't poison cached sync status on transient DB pool contention

### DIFF
--- a/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/IndexCreationMonitor.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/IndexCreationMonitor.java
@@ -13,10 +13,30 @@ public interface IndexCreationMonitor {
     /**
      * Checks if required indexes are missing, not valid, or not ready in the database.
      * Returns true if any required index is missing or not fully ready (indisvalid=false or indisready=false).
+     * <p>
+     * Implementations are expected to swallow any underlying error (e.g. a transient DB
+     * connectivity/pool issue) and fall back to {@code true} ("not ready"), since callers of
+     * this method have no previous value to fall back on and treating an unknown state as
+     * LIVE would be unsafe.
      *
      * @return true if indexes are not ready (missing, not valid, or not ready), false if all are ready
      */
     boolean isCreatingIndexes();
+
+    /**
+     * Same check as {@link #isCreatingIndexes()}, but propagates the underlying exception
+     * instead of swallowing it and returning a safe default.
+     * <p>
+     * Intended for callers that already hold a last known-good value to fall back on (e.g. a
+     * periodic background refresh) and would rather skip the update on failure than commit a
+     * false "not ready" verdict computed from a transient error (such as connection-pool
+     * contention under load) as if it were a real, current reading.
+     *
+     * @return true if indexes are not ready, false if all are ready
+     */
+    default boolean isCreatingIndexesOrThrow() {
+        return isCreatingIndexes();
+    }
 
     /**
      * Retrieves detailed information about required indexes and their status.

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusService.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusService.java
@@ -68,12 +68,31 @@ public class SyncStatusService {
      */
     @Nullable
     public Optional<SyncStatus> calculateSyncStatus(BlockIdentifierExtended latestBlock) {
+        return calculateSyncStatus(latestBlock, indexCreationMonitor.isCreatingIndexes());
+    }
+
+    /**
+     * Same calculation as {@link #calculateSyncStatus(BlockIdentifierExtended)}, but takes the
+     * index-readiness check as a precomputed value instead of calling
+     * {@link IndexCreationMonitor#isCreatingIndexes()} itself.
+     * <p>
+     * This lets {@link #refreshSyncStatus()} compute index readiness via
+     * {@link IndexCreationMonitor#isCreatingIndexesOrThrow()} up front, so a transient failure
+     * (e.g. connection-pool contention under load) can be handled by keeping the last known-good
+     * cached status instead of silently falling back to a "not ready" verdict and overwriting
+     * the value shared by every concurrent request.
+     *
+     * @param latestBlock the latest block from the blockchain
+     * @param indexesNotReady whether required database indexes are missing, not valid, or not ready
+     * @return Optional containing SyncStatus if it can be calculated, empty otherwise
+     */
+    @Nullable
+    private Optional<SyncStatus> calculateSyncStatus(BlockIdentifierExtended latestBlock, boolean indexesNotReady) {
         Optional<Long> currentSlotBasedOnTimeOpt = offlineSlotService.getCurrentSlotBasedOnTime();
 
         if (currentSlotBasedOnTimeOpt.isEmpty()) {
             // When current slot cannot be determined based on time (e.g. on DevKit where slot converters are null),
             // we assume the tip is reached and we check if the required database indexes are ready.
-            boolean indexesNotReady = indexCreationMonitor.isCreatingIndexes();
             SyncStage stage = indexesNotReady ? SyncStage.APPLYING_INDEXES : SyncStage.LIVE;
             boolean isSynced = !indexesNotReady;
 
@@ -96,9 +115,6 @@ public class SyncStatusService {
                 slotBasedOnLatestBlock,
                 allowedSlotsDelta
             );
-
-            // Check if required indexes are missing, not valid, or not ready
-            boolean indexesNotReady = indexCreationMonitor.isCreatingIndexes();
 
             // Determine sync stage and synced status
             SyncStage stage;
@@ -169,11 +185,28 @@ public class SyncStatusService {
      * result for {@link #getSyncStatus()} to serve. The rate is configurable via properties,
      * defaulting to 10 seconds. Also invoked once on startup via {@link #init()} so the first
      * requests don't see an empty status while waiting for the first scheduled tick.
+     * <p>
+     * This background thread shares the same connection pool as request-serving threads. Under
+     * heavy request load the pool can be momentarily exhausted, which would previously surface
+     * here as an {@link IndexCreationMonitor#isCreatingIndexes()} error, silently swallowed into
+     * a "not ready" default and written into {@link #cachedSyncStatus} - poisoning every
+     * concurrent request's view of sync status for up to a full refresh interval, even though
+     * the indexer itself was fine. To avoid that, this method uses
+     * {@link IndexCreationMonitor#isCreatingIndexesOrThrow()} and, on any failure (index check or
+     * the block lookup itself), logs a warning and leaves the last known-good cached value in
+     * place instead of overwriting it with a false negative.
      */
     @Scheduled(fixedRateString = "${cardano.rosetta.sync-status-refresh-rate-ms:10000}")
     public void refreshSyncStatus() {
         log.debug("[SyncStatusService] Refreshing sync status from DB");
-        BlockIdentifierExtended latestBlock = ledgerBlockService.findLatestBlockIdentifier();
-        cachedSyncStatus.set(calculateSyncStatus(latestBlock));
+        try {
+            BlockIdentifierExtended latestBlock = ledgerBlockService.findLatestBlockIdentifier();
+            boolean indexesNotReady = indexCreationMonitor.isCreatingIndexesOrThrow();
+            cachedSyncStatus.set(calculateSyncStatus(latestBlock, indexesNotReady));
+        } catch (Exception e) {
+            log.warn("[SyncStatusService] Failed to refresh sync status (e.g. transient DB or "
+                + "connection-pool contention under load) - keeping the last known-good cached "
+                + "value instead of overwriting it with a false negative.", e);
+        }
     }
 }

--- a/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/postgresql/PostgreSQLIndexCreationMonitor.java
+++ b/api/src/main/java/org/cardanofoundation/rosetta/api/network/service/postgresql/PostgreSQLIndexCreationMonitor.java
@@ -41,6 +41,28 @@ public class PostgreSQLIndexCreationMonitor implements IndexCreationMonitor {
 
     @Override
     public boolean isCreatingIndexes() {
+        try {
+            return checkCreatingIndexes();
+        } catch (Exception e) {
+            log.error("[IndexMonitor] Error checking index status", e);
+            // In case of error, assume indexes are being created to stay in APPLYING_INDEXES state
+            // This is safer than assuming LIVE state when we can't verify
+            return true;
+        }
+    }
+
+    @Override
+    public boolean isCreatingIndexesOrThrow() {
+        return checkCreatingIndexes();
+    }
+
+    /**
+     * Runs the actual pg_index/pg_class check. Does not catch anything - callers decide
+     * whether to swallow the exception (safe default of "not ready") or propagate it
+     * (e.g. so a caller with a last known-good value can choose to keep it instead of
+     * overwriting it with a false negative computed from a transient error).
+     */
+    private boolean checkCreatingIndexes() {
         List<String> requiredIndexes = rosettaIndexConfig.getIndexNames();
 
         if (requiredIndexes == null || requiredIndexes.isEmpty()) {
@@ -48,73 +70,66 @@ public class PostgreSQLIndexCreationMonitor implements IndexCreationMonitor {
             return false;
         }
 
-        try {
-            // Query pg_index system catalog to check index validity and readiness
-            // We join with pg_class to get the index name
-            Result<Record3<String, Boolean, Boolean>> result = dslContext
-                .select(
-                    org.jooq.impl.DSL.field("c.relname", String.class),
-                    org.jooq.impl.DSL.field("i.indisvalid", Boolean.class),
-                    org.jooq.impl.DSL.field("i.indisready", Boolean.class)
-                )
-                .from("pg_index i")
-                .join("pg_class c").on("i.indexrelid = c.oid")
-                .where(org.jooq.impl.DSL.field("c.relname").in(requiredIndexes))
-                .fetch();
+        // Query pg_index system catalog to check index validity and readiness
+        // We join with pg_class to get the index name
+        Result<Record3<String, Boolean, Boolean>> result = dslContext
+            .select(
+                org.jooq.impl.DSL.field("c.relname", String.class),
+                org.jooq.impl.DSL.field("i.indisvalid", Boolean.class),
+                org.jooq.impl.DSL.field("i.indisready", Boolean.class)
+            )
+            .from("pg_index i")
+            .join("pg_class c").on("i.indexrelid = c.oid")
+            .where(org.jooq.impl.DSL.field("c.relname").in(requiredIndexes))
+            .fetch();
 
-            // Build a map of index name -> status
-            Map<String, IndexStatus> indexStatusMap = result.stream()
-                .collect(Collectors.toMap(
-                    record -> record.value1(),
-                    record -> new IndexStatus(record.value2(), record.value3())
-                ));
+        // Build a map of index name -> status
+        Map<String, IndexStatus> indexStatusMap = result.stream()
+            .collect(Collectors.toMap(
+                record -> record.value1(),
+                record -> new IndexStatus(record.value2(), record.value3())
+            ));
 
-            // Check if all required indexes exist and are valid + ready
-            boolean allIndexesReady = true;
-            List<String> missingIndexes = requiredIndexes.stream()
-                .filter(indexName -> !indexStatusMap.containsKey(indexName))
-                .toList();
+        // Check if all required indexes exist and are valid + ready
+        boolean allIndexesReady = true;
+        List<String> missingIndexes = requiredIndexes.stream()
+            .filter(indexName -> !indexStatusMap.containsKey(indexName))
+            .toList();
 
-            List<String> notReadyIndexes = requiredIndexes.stream()
-                .filter(indexName -> {
-                    IndexStatus status = indexStatusMap.get(indexName);
-                    return status != null && (!status.isValid || !status.isReady);
-                })
-                .toList();
+        List<String> notReadyIndexes = requiredIndexes.stream()
+            .filter(indexName -> {
+                IndexStatus status = indexStatusMap.get(indexName);
+                return status != null && (!status.isValid || !status.isReady);
+            })
+            .toList();
 
-            if (!missingIndexes.isEmpty()) {
-                log.info("[IndexMonitor] Missing indices ({}): {}", missingIndexes.size(), missingIndexes);
-                allIndexesReady = false;
-            }
-
-            if (!notReadyIndexes.isEmpty()) {
-                log.info("[IndexMonitor] Indices not ready or not valid ({}): {}",
-                    notReadyIndexes.size(), notReadyIndexes);
-                notReadyIndexes.forEach(indexName -> {
-                    IndexStatus status = indexStatusMap.get(indexName);
-                    log.debug("[IndexMonitor] Index '{}' status: valid={}, ready={}",
-                        indexName, status.isValid, status.isReady);
-                });
-                allIndexesReady = false;
-            }
-
-            // isCreatingIndexes returns true if NOT all indexes are ready
-            // (meaning we're still in APPLYING_INDEXES state)
-            boolean creating = !allIndexesReady;
-
-            if (creating) {
-                log.info("[IndexMonitor] Indices are still being applied or not ready");
-            } else {
-                log.debug("[IndexMonitor] All required indices are valid and ready");
-            }
-
-            return creating;
-        } catch (Exception e) {
-            log.error("[IndexMonitor] Error checking index status", e);
-            // In case of error, assume indexes are being created to stay in APPLYING_INDEXES state
-            // This is safer than assuming LIVE state when we can't verify
-            return true;
+        if (!missingIndexes.isEmpty()) {
+            log.info("[IndexMonitor] Missing indices ({}): {}", missingIndexes.size(), missingIndexes);
+            allIndexesReady = false;
         }
+
+        if (!notReadyIndexes.isEmpty()) {
+            log.info("[IndexMonitor] Indices not ready or not valid ({}): {}",
+                notReadyIndexes.size(), notReadyIndexes);
+            notReadyIndexes.forEach(indexName -> {
+                IndexStatus status = indexStatusMap.get(indexName);
+                log.debug("[IndexMonitor] Index '{}' status: valid={}, ready={}",
+                    indexName, status.isValid, status.isReady);
+            });
+            allIndexesReady = false;
+        }
+
+        // isCreatingIndexes returns true if NOT all indexes are ready
+        // (meaning we're still in APPLYING_INDEXES state)
+        boolean creating = !allIndexesReady;
+
+        if (creating) {
+            log.info("[IndexMonitor] Indices are still being applied or not ready");
+        } else {
+            log.debug("[IndexMonitor] All required indices are valid and ready");
+        }
+
+        return creating;
     }
 
     @Override

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusServiceTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/SyncStatusServiceTest.java
@@ -224,7 +224,7 @@ class SyncStatusServiceTest {
             when(offlineSlotService.getCurrentSlotBasedOnTime()).thenReturn(Optional.of(currentSlot));
             when(slotRangeChecker.isSlotWithinEpsilon(currentSlot, latestBlockSlot, ALLOWED_SLOTS_DELTA))
                 .thenReturn(true);
-            when(indexCreationMonitor.isCreatingIndexes()).thenReturn(false);
+            when(indexCreationMonitor.isCreatingIndexesOrThrow()).thenReturn(false);
 
             syncStatusService.refreshSyncStatus();
 
@@ -261,7 +261,7 @@ class SyncStatusServiceTest {
             when(offlineSlotService.getCurrentSlotBasedOnTime()).thenReturn(Optional.of(currentSlot));
             when(slotRangeChecker.isSlotWithinEpsilon(currentSlot, latestBlockSlot, ALLOWED_SLOTS_DELTA))
                 .thenReturn(true);
-            when(indexCreationMonitor.isCreatingIndexes()).thenReturn(false);
+            when(indexCreationMonitor.isCreatingIndexesOrThrow()).thenReturn(false);
 
             // When
             syncStatusService.refreshSyncStatus();
@@ -282,7 +282,7 @@ class SyncStatusServiceTest {
             when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(firstBlock);
             when(offlineSlotService.getCurrentSlotBasedOnTime()).thenReturn(Optional.of(1000L));
             when(slotRangeChecker.isSlotWithinEpsilon(1000L, 800L, ALLOWED_SLOTS_DELTA)).thenReturn(false);
-            when(indexCreationMonitor.isCreatingIndexes()).thenReturn(false);
+            when(indexCreationMonitor.isCreatingIndexesOrThrow()).thenReturn(false);
 
             syncStatusService.refreshSyncStatus();
             assertThat(syncStatusService.getSyncStatus().orElseThrow().getStage())
@@ -299,6 +299,74 @@ class SyncStatusServiceTest {
             assertThat(syncStatusService.getSyncStatus().orElseThrow().getStage())
                 .isEqualTo(SyncStage.LIVE.getValue());
             verify(ledgerBlockService, times(2)).findLatestBlockIdentifier();
+        }
+
+        @Test
+        @DisplayName("Should use isCreatingIndexesOrThrow (not isCreatingIndexes) so transient errors are not swallowed into a false default")
+        void shouldUseThrowingVariantOfIndexCheck() {
+            // Given
+            BlockIdentifierExtended latestBlock = BlockIdentifierExtended.builder().slot(1000L).build();
+            when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
+            when(offlineSlotService.getCurrentSlotBasedOnTime()).thenReturn(Optional.of(1000L));
+            when(slotRangeChecker.isSlotWithinEpsilon(1000L, 1000L, ALLOWED_SLOTS_DELTA)).thenReturn(true);
+            when(indexCreationMonitor.isCreatingIndexesOrThrow()).thenReturn(false);
+
+            // When
+            syncStatusService.refreshSyncStatus();
+
+            // Then
+            verify(indexCreationMonitor, times(1)).isCreatingIndexesOrThrow();
+            verify(indexCreationMonitor, org.mockito.Mockito.never()).isCreatingIndexes();
+        }
+
+        @Test
+        @DisplayName("Should keep the last known-good cached status when the index check throws (e.g. connection-pool contention under load), instead of overwriting it with a false negative")
+        void shouldKeepLastKnownGoodStatusWhenIndexCheckThrows() {
+            // Given: a healthy first refresh establishes a known-good LIVE status
+            BlockIdentifierExtended latestBlock = BlockIdentifierExtended.builder().slot(1000L).build();
+            when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
+            when(offlineSlotService.getCurrentSlotBasedOnTime()).thenReturn(Optional.of(1000L));
+            when(slotRangeChecker.isSlotWithinEpsilon(1000L, 1000L, ALLOWED_SLOTS_DELTA)).thenReturn(true);
+            when(indexCreationMonitor.isCreatingIndexesOrThrow()).thenReturn(false);
+
+            syncStatusService.refreshSyncStatus();
+            assertThat(syncStatusService.getSyncStatus().orElseThrow().getStage())
+                .isEqualTo(SyncStage.LIVE.getValue());
+
+            // When: the next tick hits a transient failure (e.g. Hikari pool exhausted under load)
+            when(indexCreationMonitor.isCreatingIndexesOrThrow())
+                .thenThrow(new RuntimeException("connection is not available, request timed out"));
+
+            syncStatusService.refreshSyncStatus();
+
+            // Then - the previously cached LIVE status must still be served, not overwritten
+            assertThat(syncStatusService.getSyncStatus().orElseThrow().getStage())
+                .isEqualTo(SyncStage.LIVE.getValue());
+        }
+
+        @Test
+        @DisplayName("Should keep the last known-good cached status when findLatestBlockIdentifier throws")
+        void shouldKeepLastKnownGoodStatusWhenLatestBlockLookupThrows() {
+            // Given: a healthy first refresh establishes a known-good LIVE status
+            BlockIdentifierExtended latestBlock = BlockIdentifierExtended.builder().slot(1000L).build();
+            when(ledgerBlockService.findLatestBlockIdentifier()).thenReturn(latestBlock);
+            when(offlineSlotService.getCurrentSlotBasedOnTime()).thenReturn(Optional.of(1000L));
+            when(slotRangeChecker.isSlotWithinEpsilon(1000L, 1000L, ALLOWED_SLOTS_DELTA)).thenReturn(true);
+            when(indexCreationMonitor.isCreatingIndexesOrThrow()).thenReturn(false);
+
+            syncStatusService.refreshSyncStatus();
+            assertThat(syncStatusService.getSyncStatus().orElseThrow().getStage())
+                .isEqualTo(SyncStage.LIVE.getValue());
+
+            // When: the next tick's block lookup fails (e.g. pool exhausted)
+            when(ledgerBlockService.findLatestBlockIdentifier())
+                .thenThrow(new RuntimeException("connection is not available, request timed out"));
+
+            syncStatusService.refreshSyncStatus();
+
+            // Then - the previously cached LIVE status must still be served, not cleared/overwritten
+            assertThat(syncStatusService.getSyncStatus().orElseThrow().getStage())
+                .isEqualTo(SyncStage.LIVE.getValue());
         }
     }
 }

--- a/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/postgresql/PostgreSQLIndexCreationMonitorTest.java
+++ b/api/src/test/java/org/cardanofoundation/rosetta/api/network/service/postgresql/PostgreSQLIndexCreationMonitorTest.java
@@ -94,6 +94,37 @@ class PostgreSQLIndexCreationMonitorTest {
     }
 
     @Nested
+    @DisplayName("isCreatingIndexesOrThrow tests")
+    class IsCreatingIndexesOrThrowTests {
+
+        @Test
+        @DisplayName("Should propagate the exception instead of swallowing it")
+        void shouldPropagateExceptionOnDatabaseError() {
+            // Given
+            when(rosettaIndexConfig.getIndexNames()).thenReturn(REQUIRED_INDEX_NAMES);
+            when(dslContext.select(any(), any(), any())).thenThrow(new RuntimeException("Database error"));
+
+            // When/Then - unlike isCreatingIndexes(), this must not swallow the error
+            org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+                () -> monitor.isCreatingIndexesOrThrow());
+        }
+
+        @Test
+        @DisplayName("Should return false when no indexes are configured, without querying")
+        void shouldReturnFalseWhenNoIndexesConfigured() {
+            // Given
+            when(rosettaIndexConfig.getIndexNames()).thenReturn(Collections.emptyList());
+
+            // When
+            boolean creating = monitor.isCreatingIndexesOrThrow();
+
+            // Then
+            assertThat(creating).isFalse();
+            verify(dslContext, never()).select(any(), any(), any());
+        }
+    }
+
+    @Nested
     @DisplayName("getIndexCreationProgress - configuration tests")
     class GetIndexCreationProgressConfigTests {
 


### PR DESCRIPTION
SyncStatusService.refreshSyncStatus() runs on a background scheduler thread that shares HikariCP's fixed-size pool with request-serving threads. Under heavy load, PostgreSQLIndexCreationMonitor.isCreatingIndexes() silently swallowed pool contention/timeout errors and returned a safe "not ready" default - which refreshSyncStatus() then wrote into the single cachedSyncStatus shared by every concurrent request, failing all of them for up to a full refresh interval even though the indexer was actually healthy.

Add IndexCreationMonitor.isCreatingIndexesOrThrow(), a variant that propagates the exception instead of swallowing it. refreshSyncStatus() now uses it (and catches around the whole refresh, including the latest-block lookup) so a transient failure just leaves the last known-good cached status in place instead of overwriting it with a false negative. isCreatingIndexes()'s existing swallow-and-default behavior is unchanged for its other caller (SyncStatusHealthIndicator).