### PR TITLE
docs: add 2.2.0 and 2.3.0 mid_profile load test results

### DIFF
--- a/docs/docs/development/performance-measurements.md
+++ b/docs/docs/development/performance-measurements.md
@@ -7,6 +7,8 @@ description: Performance measurement methodologies and results
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import MidDockerCompose230 from './test-results/2.3.0/mid_profile/docker-compose.md';
+import MidDockerCompose220 from './test-results/2.2.0/mid_profile/docker-compose.md';
 import MidDockerCompose210 from './test-results/2.1.0/mid_profile/docker-compose.md';
 import MidDockerCompose200 from './test-results/2.0.0/mid_profile/docker-compose.md';
 
@@ -59,6 +61,48 @@ Load tests are conducted using Apache Bench (ab) with a ramp-up strategy, progre
 :::tip
 To better understand the environments in which these results were obtained, please refer to our [hardware profiles documentation](../install-and-deploy/hardware-profiles).
 :::
+
+<details>
+<summary>
+### v2.3.0 (Jul 22, 2026)
+</summary>
+- [Release Notes](https://github.com/cardano-foundation/cardano-rosetta-java/releases/tag/2.3.0)
+
+<details>
+<summary>
+ **Mid-level Hardware Profile**
+</summary>
+**Machine Specs:** 8 vCPUs, 48GB RAM
+<details>
+<Tabs>
+  <TabItem value="mid_docker_compose230" label="Docker Compose" default>
+    <MidDockerCompose230 />
+  </TabItem>
+</Tabs>
+</details>
+</details>
+</details>
+
+<details>
+<summary>
+### v2.2.0 (May 26, 2026)
+</summary>
+- [Release Notes](https://github.com/cardano-foundation/cardano-rosetta-java/releases/tag/2.2.0)
+
+<details>
+<summary>
+ **Mid-level Hardware Profile**
+</summary>
+**Machine Specs:** 8 vCPUs, 48GB RAM
+<details>
+<Tabs>
+  <TabItem value="mid_docker_compose220" label="Docker Compose" default>
+    <MidDockerCompose220 />
+  </TabItem>
+</Tabs>
+</details>
+</details>
+</details>
 
 <details>
 <summary>

--- a/docs/docs/development/test-results/2.2.0/mid_profile/docker-compose.md
+++ b/docs/docs/development/test-results/2.2.0/mid_profile/docker-compose.md
@@ -1,0 +1,12 @@
+The performance metrics in this table were measured against an SLA of 1000 ms.
+
+| ID | Endpoint                              | Max Concurrency | p95 (ms) | p99 (ms) | Non-2xx | Error Rate (%) | Reqs/sec   |
+|----|---------------------------------------|------------------|----------|----------|---------|----------------|------------|
+| 1  | /network/status                       | 125              | 55       | 67       | 0       | 0.00%          | 3907.71    |
+| 2  | /account/balance                      | 100              | 611      | 756      | 0       | 0.00%          | 268.82     |
+| 3  | /account/coins                        | 100              | 592      | 808      | 0       | 0.00%          | 287.80     |
+| 4  | /block                                | 150              | 603      | 742      | 0       | 0.00%          | 420.77     |
+| 5  | /block/transaction                    | 175              | 622      | 771      | 0       | 0.00%          | 476.30     |
+| 6  | /search/transactions (by hash)        | 175              | 166      | 237      | 201     | 0.40%          | 1395.38    |
+| 7  | /search/transactions (by address)     | 20               | 869      | 999      | 0       | 0.00%          | 29.96      |
+| 8  | /construction/metadata                | 500              | 138      | 341      | 0       | 0.00%          | 8418.45    |

--- a/docs/docs/development/test-results/2.3.0/mid_profile/docker-compose.md
+++ b/docs/docs/development/test-results/2.3.0/mid_profile/docker-compose.md
@@ -1,0 +1,12 @@
+The performance metrics in this table were measured against an SLA of 1000 ms.
+
+| ID | Endpoint                              | Max Concurrency | p95 (ms) | p99 (ms) | Non-2xx | Error Rate (%) | Reqs/sec   |
+|----|---------------------------------------|------------------|----------|----------|---------|----------------|------------|
+| 1  | /network/status                       | 125              | 62       | 77       | 0       | 0.00%          | 3340.80    |
+| 2  | /account/balance                      | 100              | 612      | 737      | 0       | 0.00%          | 266.31     |
+| 3  | /account/coins                        | 100              | 605      | 865      | 0       | 0.00%          | 285.75     |
+| 4  | /block                                | 175              | 744      | 914      | 0       | 0.00%          | 405.32     |
+| 5  | /block/transaction                    | 175              | 652      | 807      | 0       | 0.00%          | 455.24     |
+| 6  | /search/transactions (by hash)        | 150              | 135      | 175      | 0       | 0.00%          | 1987.31    |
+| 7  | /search/transactions (by address)     | 20               | 844      | 937      | 0       | 0.00%          | 30.65      |
+| 8  | /construction/metadata                | 500              | 281      | 444      | 0       | 0.00%          | 7235.16    |


### PR DESCRIPTION
- Add Docker Compose mid_profile load test results for the 2.2.0 and 2.3.0 releases under `docs/docs/development/test-results/`, following the existing format.
- Wire the new results into `performance-measurements.md` (imports + collapsible sections, matching the pattern used for 2.0.0/2.1.0).